### PR TITLE
更新assets/interface.json

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -13,7 +13,7 @@
             "type": "Win32",
             "win32": {
                 "class_regex": ".*",
-                "window_regex": "异环",
+                "window_regex": "^异环.*$",
                 "screencap": "FramePool",
                 "mouse": "SendMessageWithWindowPos",
                 "keyboard": "SendMessageWithWindowPos"


### PR DESCRIPTION
有时候模糊匹配窗口识别会选择MaaNTE异环小助手，更新之后强制匹配异环开头可以避免错误识别