### PR TITLE
fix: 修复版本号带v前缀导致无限更新循环的问题

### DIFF
--- a/tools/ci/install.py
+++ b/tools/ci/install.py
@@ -68,7 +68,7 @@ def install_resource():
     with open(install_path / "interface.json", "r", encoding="utf-8") as f:
         interface = json.load(f)
 
-    interface["version"] = version
+    interface["version"] = version.lstrip("v")
     interface["title"] = f"MaaNTE {version} | 异环小助手"
 
     with open(install_path / "interface.json", "w", encoding="utf-8") as f:


### PR DESCRIPTION
## 问题

Fixes #8

用户在 v0.0.3 版本上不断收到更新通知，下载更新后重启仍然提示更新，形成无限循环。

## 原因

CI 构建时 `install.py` 将 git tag（如 `v0.0.3`）直接写入 `interface.json` 的 `version` 字段，而源文件中 version 格式为 `0.0.1`（无 "v" 前缀）。

MFAAvalonia 客户端在比较本地版本与远程版本时，由于 "v" 前缀不一致，导致版本比较始终判定为"需要更新"。

## 修复

在 `tools/ci/install.py` 中对写入 `interface.json` 的版本号执行 `lstrip("v")`，确保版本格式一致：

```diff
- interface["version"] = version
+ interface["version"] = version.lstrip("v")
```

## 测试

- `v0.0.3` → `0.0.3`
- `v0.0.3-hotfix2` → `0.0.3-hotfix2`
- `v0.0.4-preview-1` → `0.0.4-preview-1`
- `0.0.3`（已无前缀）→ `0.0.3`（不受影响）