### PR TITLE
fix: 修复钓鱼不定时中断及判定条失控

### DIFF
--- a/agent/custom/action/auto_buy_fish_bait.py
+++ b/agent/custom/action/auto_buy_fish_bait.py
@@ -43,11 +43,13 @@ class AutoBuyFishBait(CustomAction):
         shell_count_region = [961, 31, 70, 21]
         KEY_R = 82
         KEY_ESC = 27
-        controller = context.tasker.controller  
+        controller = context.tasker.controller
         print("=== AutoBuyFishBait Action Started ===")
 
         match_threshold = 0.7
         while True:
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_bait, prob, x, y = match_template_in_region(img, fish_shop_region, self.bait_template, match_threshold)
             print(f"Clicked on bait at ({x+15}, {y+5}), probability: {prob:.2f}")
@@ -55,7 +57,7 @@ class AutoBuyFishBait(CustomAction):
                 for _ in range(3):
                     click_rect(controller, [x, y, 30, 10])
                     time.sleep(0.1)
-                
+
                 img = get_image(controller)
                 found_bait_success, _, _, _ = match_template_in_region(img, find_bait_success_region, self.find_bait_success_template, match_threshold)
                 if found_bait_success:
@@ -64,11 +66,13 @@ class AutoBuyFishBait(CustomAction):
                     break
             else:
                 print("Bait not found in fish shop, retrying...")
-                controller.post_click_key(KEY_R).wait()  
+                controller.post_click_key(KEY_R).wait()
                 time.sleep(1)
                 continue
 
         while True:
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_select_max, _, _, _ = match_template_in_region(img, select_max_region, self.select_max_template, match_threshold)
             if found_select_max:
@@ -80,8 +84,10 @@ class AutoBuyFishBait(CustomAction):
             else:
                 print("Select max option not found, retrying...")
                 time.sleep(1)
-        
+
         while True:
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_buy, _, _, _ = match_template_in_region(img, buy_region, self.buy_template, match_threshold)
             if found_buy:
@@ -95,6 +101,8 @@ class AutoBuyFishBait(CustomAction):
                 time.sleep(1)
 
         for _ in range(5):
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_buy_confirm, _, _, _ = match_template_in_region(img, buy_confirm_region, self.buy_confirm_template, match_threshold)
             if found_buy_confirm:
@@ -108,6 +116,8 @@ class AutoBuyFishBait(CustomAction):
                 time.sleep(0.2)
 
         while True:
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_buy_success, _, _, _ = match_template_in_region(img, buy_success_region, self.buy_success_template, match_threshold)
             if found_buy_success:
@@ -117,6 +127,6 @@ class AutoBuyFishBait(CustomAction):
                 break
             else:
                 print("Buy success confirmation not found, retrying...")
-                time.sleep(1)                
+                time.sleep(1)
 
         return CustomAction.RunResult(success=True)

--- a/agent/custom/action/auto_fish.py
+++ b/agent/custom/action/auto_fish.py
@@ -85,6 +85,8 @@ class AutoFish(CustomAction):
         game_region = (400, 33, 882, 63)
         escape_region = (590, 349, 689, 371)
 
+        last_target = None
+
         for i in range(fishing_count):
             if context.tasker.stopping:
                 return CustomAction.RunResult(success=False)
@@ -93,12 +95,26 @@ class AutoFish(CustomAction):
             while True:
                 if context.tasker.stopping:
                     return CustomAction.RunResult(success=False)
+
+                # 先尝试关闭可能残留的结算界面
+                img = get_image(controller)
+                m_settle, _, _, _ = match_template_in_region(img, settlement_region, self.continue_template, 0.8)
+                if m_settle:
+                    print("  Settlement screen detected before casting, closing...")
+                    self._dismiss_settlement(controller, settlement_region)
+                    time.sleep(0.5)
+                    continue
+
                 controller.post_key_down(KEY_F)
                 time.sleep(0.1)
                 controller.post_key_up(KEY_F)
                 print("  Casting...")
 
-                while True:
+                # 等待上钩，添加超时防止卡死
+                hook_start = time.time()
+                hook_timeout = 60
+                hooked = False
+                while time.time() - hook_start < hook_timeout:
                     if context.tasker.stopping:
                         return CustomAction.RunResult(success=False)
                     time.sleep(check_freq)
@@ -109,8 +125,15 @@ class AutoFish(CustomAction):
                         time.sleep(0.1)
                         controller.post_key_up(KEY_F)
                         print("  Fish hooked!")
+                        hooked = True
                         break
-      
+
+                if not hooked:
+                    print("  Hook timeout, recasting...")
+                    controller.post_key_up(KEY_F)
+                    time.sleep(0.5)
+                    continue
+
                 start_time = time.time()
                 frame = 0
                 deadzone = 15
@@ -136,63 +159,89 @@ class AutoFish(CustomAction):
                     m_right, _, x_right, _ = match_template_in_region(img, game_region, self.valid_region_right_template, 0.7)
                     m_slider, _, x_slider, _ = match_template_in_region(img, game_region, self.slider_template, 0.7)
 
-                    if m_slider:                      
+                    if m_slider:
                         if frame % 10 == 0:
                             controller.post_key_down(KEY_F)
                             time.sleep(0.05)
                             controller.post_key_up(KEY_F)
-            
+
                         if m_left and m_right:
                             target = (x_left + x_right) / 2
+                            last_target = target
                             offset = x_slider - target
                         elif not m_left and m_right:
                             target = x_right
+                            last_target = target
                             offset = x_slider - target
                         elif m_left and not m_right:
                             target = x_left
+                            last_target = target
                             offset = x_slider - target
+                        elif last_target is not None:
+                            offset = x_slider - last_target
                         else:
                             offset = 0
 
-                        if m_left or m_right:
-                            if offset > deadzone:
-                                controller.post_key_up(KEY_D)
-                                controller.post_key_down(KEY_A)
-                            elif offset < -deadzone:
-                                controller.post_key_up(KEY_A)
-                                controller.post_key_down(KEY_D)
-                            else:
-                                controller.post_key_up(KEY_A)
-                                controller.post_key_up(KEY_D)
-                
+                        if offset > deadzone:
+                            controller.post_key_up(KEY_D)
+                            controller.post_key_down(KEY_A)
+                        elif offset < -deadzone:
+                            controller.post_key_up(KEY_A)
+                            controller.post_key_down(KEY_D)
+                        else:
+                            controller.post_key_up(KEY_A)
+                            controller.post_key_up(KEY_D)
+
                 controller.post_key_up(KEY_D)
                 controller.post_key_up(KEY_A)
                 controller.post_key_up(KEY_F)
-                
+
                 img = get_image(controller)
                 time.sleep(0.3)
                 m_escape, _, _, _ = match_template_in_region(img, escape_region, self.escape_template, 0.8)
                 if m_escape:
-                    continue  
-                break  
+                    continue
+                break
 
             print("  Finished.")
 
+            # 关闭结算界面
             img = get_image(controller)
             match_settle, _, _, _ = match_template_in_region(img, settlement_region, self.continue_template, 0.8)
             if match_settle:
                 print("  Closing settlement screen...")
-                for _ in range(5):
-                    controller.post_key_down(KEY_ESC)
-                    time.sleep(0.1)
-                    controller.post_key_up(KEY_ESC)
-                    time.sleep(1)
-
-                    img = get_image(controller)
-                    m, _, _, _ = match_template_in_region(img, settlement_region, self.continue_template, 0.8)
-                    if not m:
-                        print("  Settlement closed.")
-                        break
+                self._dismiss_settlement(controller, settlement_region)
 
         print("All fishing tasks complete.")
         return CustomAction.RunResult(success=True)
+
+    def _dismiss_settlement(self, controller, settlement_region):
+        """尝试关闭结算界面，使用多种方式"""
+        KEY_ESC = 27
+        for attempt in range(10):
+            # 尝试 ESC
+            controller.post_key_down(KEY_ESC)
+            time.sleep(0.1)
+            controller.post_key_up(KEY_ESC)
+            time.sleep(0.5)
+
+            img = get_image(controller)
+            m, _, _, _ = match_template_in_region(img, settlement_region, self.continue_template, 0.8)
+            if not m:
+                print("  Settlement closed.")
+                return
+
+            # 尝试鼠标点击屏幕中央
+            if attempt % 3 == 1:
+                controller.post_click(640, 360).wait()
+                time.sleep(0.5)
+
+            # 尝试空格/回车
+            if attempt % 3 == 2:
+                for key in [32, 13]:  # Space, Enter
+                    controller.post_key_down(key)
+                    time.sleep(0.1)
+                    controller.post_key_up(key)
+                    time.sleep(0.3)
+
+        print("  Warning: Failed to dismiss settlement screen after 10 attempts.")

--- a/agent/custom/action/auto_sell_fish.py
+++ b/agent/custom/action/auto_sell_fish.py
@@ -33,12 +33,12 @@ class AutoSellFish(CustomAction):
     sell_fail_template = cv2.imread(str(sell_fail_img), cv2.IMREAD_COLOR)
 
     def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
-        print("=== Autofish Action Started ===")
+        print("=== AutoSellFish Action Started ===")
         controller = context.tasker.controller
 
         KEY_Q = 81
         KEY_ESC = 27
-        
+
         no_fish_to_sell_region = [433, 457, 77, 20]
         sell_option_region = [63, 247, 66, 57]
         sell_option_selected_region = [172, 166, 103, 29]
@@ -47,45 +47,53 @@ class AutoSellFish(CustomAction):
         sell_success_region = [565, 628, 149, 21]
         sell_fail_region = [739, 349, 202, 24]
         no_valid_fish_region = [509, 350, 261, 22]
-        
+
         while True:
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_sell_option, _, _, _ = match_template_in_region(img, sell_option_region, self.sell_option_template, 0.7)
             if found_sell_option:
                 for _ in range(3):
                     click_rect(controller, sell_option_region)
                     time.sleep(0.1)
-                
+
                 img = get_image(controller)
                 found_sell_option_selected, _, _, _ = match_template_in_region(img, sell_option_selected_region, self.sell_option_selected_template, 0.8)
                 if found_sell_option_selected:
                     break
-                time.sleep(1)  
+                time.sleep(1)
             else:
-                controller.post_click_key(KEY_Q).wait()  
-                time.sleep(1)  
+                controller.post_click_key(KEY_Q).wait()
+                time.sleep(1)
 
         print("Sell option detected. Proceeding to sell fish.")
 
         for _ in range(5):
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_no_fish_to_sell, prob, _, _ = match_template_in_region(img, no_fish_to_sell_region, self.no_fish_to_sell_template, 0.8)
             time.sleep(0.1)
             if found_no_fish_to_sell:
                 print("No fish to sell detected. Closing fish shop.")
-                controller.post_click_key(KEY_ESC).wait()  
+                controller.post_click_key(KEY_ESC).wait()
                 return CustomAction.RunResult(success=True)
-        
+
         while True:
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_sell_button, _, _, _ = match_template_in_region(img, sell_button_region, self.sell_button_template, 0.8)
             if found_sell_button:
                 print("Sell button detected. Clicking to confirm selling fish.")
                 while True:
+                    if context.tasker.stopping:
+                        return CustomAction.RunResult(success=False)
                     for _ in range(3):
                         click_rect(controller, sell_button_region)
                         time.sleep(0.1)
-                        
+
                     img = get_image(controller)
                     found_confirm_sell, _, _, _ = match_template_in_region(img, confirm_sell_region, self.confirm_sell_template, 0.8)
                     sell_fail, _, _, _ = match_template_in_region(img, sell_fail_region, self.sell_fail_template, 0.8)
@@ -94,10 +102,10 @@ class AutoSellFish(CustomAction):
                         for _ in range(3):
                             click_rect(controller, confirm_sell_region)
                             time.sleep(0.1)
-                        time.sleep(1)  
+                        time.sleep(1)
                         break
                     elif sell_fail:
-                        print("no fish to sell, closing fish shop.")
+                        print("No fish to sell, closing fish shop.")
                         controller.post_click_key(KEY_ESC).wait()
                         return CustomAction.RunResult(success=True)
                     else:
@@ -107,16 +115,18 @@ class AutoSellFish(CustomAction):
                 time.sleep(0.1)
 
         while True:
+            if context.tasker.stopping:
+                return CustomAction.RunResult(success=False)
             img = get_image(controller)
             found_sell_success, _, _, _ = match_template_in_region(img, sell_success_region, self.sell_success_template, 0.8)
             if found_sell_success:
                 print("Sell success detected. Fish sold successfully.")
-                controller.post_click_key(KEY_ESC).wait()  
+                controller.post_click_key(KEY_ESC).wait()
                 time.sleep(0.5)
                 controller.post_click_key(KEY_ESC).wait()
                 break
             else:
                 time.sleep(1)
-        
-        print("All fishing tasks complete.")
+
+        print("All sell tasks complete.")
         return CustomAction.RunResult(success=True)


### PR DESCRIPTION
## 问题

Fixes #23

用户反馈钓鱼模式在一定次数后不定时停止，停在"此次收获"界面。同时判定条超出范围时脚本不操控，导致鱼溜走。

## 原因

1. `auto_fish.py` 中"等待上钩"循环无超时机制，若结算界面未关闭会永久卡死
2. 判定条左右边缘检测失败时 `offset=0` 不做任何操控，滑块自由漂移
3. `auto_sell_fish.py` 和 `auto_buy_fish_bait.py` 的 `while True` 循环无 `context.tasker.stopping` 检查，无法正常中断

## 修改

### auto_fish.py
- 等待上钩添加 60 秒超时，超时后自动重抛
- 抛竿前检测残留结算界面并尝试关闭
- 结算界面关闭改为 ESC + 鼠标点击 + 空格/回车多种方式（10次尝试）
- 判定条边缘检测失败时使用上次已知位置继续操控，避免原地等待

### auto_sell_fish.py
- 所有 `while True` 循环添加 `context.tasker.stopping` 检查
- 修正日志文案错误（"Autofish" → "AutoSellFish"）

### auto_buy_fish_bait.py
- 所有 `while True` 循环添加 `context.tasker.stopping` 检查