### PR TITLE
fix(rhythm): 修复选曲回滚误触与连打活力检测

### DIFF
--- a/agent/custom/action/rhythm/feats/__init__.py
+++ b/agent/custom/action/rhythm/feats/__init__.py
@@ -1,3 +1,3 @@
 from .select_song import AutoRhythmSelectSong
 from .play import AutoRhythmPlay
-from .repeat_decision import AutoRhythmRepeatDecision
+from .repeat_decision import AutoRhythmRepeatDecision, AutoRhythmVitalityOnResults

--- a/agent/custom/action/rhythm/feats/play.py
+++ b/agent/custom/action/rhythm/feats/play.py
@@ -25,7 +25,6 @@ _VK = {"d": 0x44, "f": 0x46, "j": 0x4A, "k": 0x4B}
 _TIMEOUT_SEC = 600
 _SCENE_LOCK_SEC = 8.0
 _PLAYING_CHECK_THRESHOLD = 0.7
-_MIN_CONFIRM_NOT_PLAYING = 3
 
 
 def _press_keys(controller, lane_indices: list[int], key_hold_sec: float = 0.01):
@@ -100,12 +99,6 @@ class AutoRhythmPlay(CustomAction):
         scene_lock_sec = float(
             cfg.get("scene", {}).get("song_select_to_playing_lock_sec", _SCENE_LOCK_SEC)
         )
-        confirm_not_playing = max(
-            _MIN_CONFIRM_NOT_PLAYING,
-            int(
-                cfg.get("scene", {}).get("state_confirm_frames", _MIN_CONFIRM_NOT_PLAYING)
-            ),
-        )
 
         detector = DrumDetector(cfg)
         drum_available = detector.available
@@ -113,13 +106,12 @@ class AutoRhythmPlay(CustomAction):
             logger.warning("鼓面模板缺失，演奏检测不可用")
 
         logger.info(
-            "演奏开始 | FPS=%d | 鼓面检测=%s | 场景冷却=%.1fs(音符命中重置) | 退出确认=%d帧",
-            target_fps, drum_available, scene_lock_sec, confirm_not_playing,
+            "演奏开始 | FPS=%d | 鼓面检测=%s | 场景冷却=%.1fs(音符命中重置)",
+            target_fps, drum_available, scene_lock_sec,
         )
 
         start_time = time.perf_counter()
         frame_count = 0
-        not_playing_streak = 0
         cached_layout: LaneLayout | None = None
         cached_layout_size: tuple[int, int] = (0, 0)
         playing_tpl = self._playing_check_template
@@ -163,20 +155,16 @@ class AutoRhythmPlay(CustomAction):
                 triggered_lanes = [i for i, t in enumerate(triggers) if t]
                 if triggered_lanes:
                     scene_lock_until = now + scene_lock_sec
-                    not_playing_streak = 0
                     _press_keys(controller, triggered_lanes, key_hold_sec)
 
             if now >= scene_lock_until:
                 if not _is_still_playing(frame, playing_tpl):
-                    not_playing_streak += 1
-                    if not_playing_streak >= confirm_not_playing:
-                        logger.info(
-                            "演奏结束 (帧#%d, 耗时%.1f秒, 连续未匹配%d帧)",
-                            frame_count, elapsed_total, not_playing_streak,
-                        )
-                        return CustomAction.RunResult(success=True)
-                else:
-                    not_playing_streak = 0
+                    logger.info(
+                        "演奏结束 (帧#%d, 耗时%.1f秒, 冷却锁过期，识别为非playing)",
+                        frame_count, elapsed_total,
+                    )
+                    return CustomAction.RunResult(success=True)
+                scene_lock_until = now + scene_lock_sec
 
             elapsed_frame = time.perf_counter() - t0
             if elapsed_frame < frame_interval:

--- a/agent/custom/action/rhythm/feats/repeat_decision.py
+++ b/agent/custom/action/rhythm/feats/repeat_decision.py
@@ -1,7 +1,10 @@
 import json
 import logging
 import re
+import time
 from typing import Any
+
+import cv2
 
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
@@ -13,32 +16,137 @@ from ..utils.config import load_rhythm_config
 
 logger = logging.getLogger(__name__)
 
-_COST_VITALITY_ROI = (540, 594, 187, 35)
-_COST_VITALITY_PATTERN = re.compile(r"-\s*(\d+)")
+_DEFAULT_ROI = (544, 622, 184, 46)
+_DEFAULT_COST_PATTERN = r"(\d+)"
+_DEFAULT_MIN_CONFIRM_READS = 2
+_DEFAULT_CONFIRM_INTERVAL_SEC = 0.3
+_DEFAULT_VITALITY_THRESHOLD = 1
 
 _repeat_index: int = 0
+_vitality_cost: int | None = None
 
 
-def _detect_cost_vitality(context: Context, frame: Any) -> int:
+def _detect_cost_vitality(context: Context, frame: Any, cfg: dict[str, Any]) -> int:
     if frame is None or frame.size == 0:
         return 0
 
-    detail = context.run_recognition_direct(
-        JRecognitionType.OCR, JOCR(roi=_COST_VITALITY_ROI), frame
+    vcfg = cfg.get("vitality_detect") or {}
+    roi_list = vcfg.get("roi", list(_DEFAULT_ROI))
+    roi = (
+        tuple(roi_list)
+        if isinstance(roi_list, list) and len(roi_list) == 4
+        else _DEFAULT_ROI
     )
-    if detail is None or not detail.hit or detail.best_result is None:
-        logger.debug("消耗活力 OCR 未命中")
-        return 0
+    cost_pattern_str = str(vcfg.get("cost_pattern", _DEFAULT_COST_PATTERN))
+    min_confirm = max(1, int(vcfg.get("min_confirm_reads", _DEFAULT_MIN_CONFIRM_READS)))
+    confirm_interval = float(
+        vcfg.get("confirm_interval_sec", _DEFAULT_CONFIRM_INTERVAL_SEC)
+    )
 
-    text = detail.best_result.text if hasattr(detail.best_result, "text") else str(detail.best_result)
-    m = _COST_VITALITY_PATTERN.search(text)
-    if m:
-        cost = int(m.group(1))
-        logger.debug("消耗活力 OCR: %s -> %d", text, cost)
-        return cost
+    try:
+        cost_pattern = re.compile(cost_pattern_str)
+    except re.error:
+        logger.warning("活力检测正则无效: %s，使用默认", cost_pattern_str)
+        cost_pattern = re.compile(_DEFAULT_COST_PATTERN)
 
-    logger.debug("消耗活力 OCR 未匹配: %s", text)
+    confirmed_costs: list[int] = []
+    last_text = ""
+
+    for attempt in range(min_confirm + 2):
+        if attempt > 0:
+            time.sleep(confirm_interval)
+            controller = context.tasker.controller
+            controller.post_screencap().wait()
+            frame = controller.cached_image
+            if frame is None or frame.size == 0:
+                continue
+            if len(frame.shape) == 3 and frame.shape[2] == 4:
+
+                frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
+
+        detail = context.run_recognition_direct(
+            JRecognitionType.OCR, JOCR(roi=roi), frame
+        )
+        if detail is None or not detail.hit or detail.best_result is None:
+            logger.debug(
+                "消耗活力 OCR 未命中 (尝试 %d/%d)", attempt + 1, min_confirm + 2
+            )
+            continue
+
+        text = (
+            detail.best_result.text
+            if hasattr(detail.best_result, "text")
+            else str(detail.best_result)
+        )
+        if text:
+            last_text = text
+        m = cost_pattern.search(text)
+        if m:
+            cost = int(m.group(1))
+            logger.debug(
+                "消耗活力 OCR: %s -> %d (尝试 %d/%d)",
+                text,
+                cost,
+                attempt + 1,
+                min_confirm + 2,
+            )
+            confirmed_costs.append(cost)
+            if len(confirmed_costs) >= min_confirm:
+                break
+        else:
+            logger.debug(
+                "消耗活力 OCR 未匹配: %s (尝试 %d/%d)",
+                text,
+                attempt + 1,
+                min_confirm + 2,
+            )
+
+    if confirmed_costs:
+        from collections import Counter
+
+        most_common_cost, count = Counter(confirmed_costs).most_common(1)[0]
+        logger.info(
+            "活力消耗确认: %d (出现 %d/%d 次, 原始: %s)",
+            most_common_cost,
+            count,
+            len(confirmed_costs),
+            last_text,
+        )
+        return most_common_cost
+
+    if last_text:
+        logger.warning("活力检测: 多次 OCR 均未能匹配消耗值，最后文本: %s", last_text)
+    else:
+        logger.warning("活力检测: 所有 OCR 尝试均未命中，可能活力耗尽或区域错误")
+
     return 0
+
+
+@AgentServer.custom_action("auto_rhythm_vitality_on_results")
+class AutoRhythmVitalityOnResults(CustomAction):
+    def run(
+        self, context: Context, argv: CustomAction.RunArg
+    ) -> CustomAction.RunResult:
+        global _vitality_cost
+
+        cfg = load_rhythm_config()
+        vcfg = cfg.get("vitality_detect") or {}
+        vitality_enabled = bool(vcfg.get("enabled", True))
+
+        if not vitality_enabled:
+            logger.debug("活力检测已禁用，跳过结算页 OCR")
+            _vitality_cost = None
+            return CustomAction.RunResult(success=True)
+
+        controller = context.tasker.controller
+        controller.post_screencap().wait()
+        frame = controller.cached_image
+        if frame is not None and len(frame.shape) == 3 and frame.shape[2] == 4:
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
+        cost = _detect_cost_vitality(context, frame, cfg)
+        _vitality_cost = cost
+        logger.info("结算页活力消耗: %d", cost)
+        return CustomAction.RunResult(success=True)
 
 
 @AgentServer.custom_action("auto_rhythm_repeat_decision")
@@ -46,7 +154,7 @@ class AutoRhythmRepeatDecision(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
-        global _repeat_index
+        global _repeat_index, _vitality_cost
 
         cfg = load_rhythm_config()
 
@@ -72,15 +180,27 @@ class AutoRhythmRepeatDecision(CustomAction):
         should_exit = False
 
         if auto_repeat_max:
-            controller = context.tasker.controller
-            controller.post_screencap().wait()
-            frame = controller.cached_image
-            if frame is not None and len(frame.shape) == 3 and frame.shape[2] == 4:
-                import cv2
-                frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
-            cost = _detect_cost_vitality(context, frame)
-            if cost == 0:
-                logger.info("活力耗尽，停止连打")
+            vcfg = cfg.get("vitality_detect") or {}
+            vitality_threshold = int(
+                vcfg.get("vitality_threshold", _DEFAULT_VITALITY_THRESHOLD)
+            )
+
+            cost = _vitality_cost
+            if cost is None:
+                logger.warning("未获取结算页活力消耗值，尝试现场识别")
+                controller = context.tasker.controller
+                controller.post_screencap().wait()
+                frame = controller.cached_image
+                if frame is not None and len(frame.shape) == 3 and frame.shape[2] == 4:
+                    frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
+                cost = _detect_cost_vitality(context, frame, cfg)
+
+            if cost < vitality_threshold:
+                logger.info(
+                    "活力已耗尽 (消耗=%d < 阈值=%d)，停止连打",
+                    cost,
+                    vitality_threshold,
+                )
                 should_exit = True
             else:
                 logger.info("消耗活力 %d，继续连打", cost)
@@ -94,6 +214,7 @@ class AutoRhythmRepeatDecision(CustomAction):
 
         if should_exit:
             _repeat_index = 0
+            _vitality_cost = None
             context.override_next("RhythmRepeatCheck", ["RhythmExit"])
         else:
             context.override_next("RhythmRepeatCheck", ["[Anchor]RhythmLoopPoint"])

--- a/agent/custom/action/rhythm/feats/select_song.py
+++ b/agent/custom/action/rhythm/feats/select_song.py
@@ -76,8 +76,8 @@ class AutoRhythmSelectSong(CustomAction):
 
             if state == STATE_SONG_SELECT:
                 scroll_fn = lambda sx, sy, sd: (
-                    controller.post_swipe(sx, sy, sx, sy + sd * 100, duration=100).wait(),
-                    time.sleep(0.1),
+                    controller.post_swipe(sx, sy, sx, sy + sd * 100, duration=250).wait(),
+                    time.sleep(0.15),
                 )
                 sel_info = song_selector.step(
                     frame, controller, scroll_func=scroll_fn

--- a/agent/custom/action/rhythm/utils/config.py
+++ b/agent/custom/action/rhythm/utils/config.py
@@ -46,11 +46,22 @@ _DEFAULT_CONFIG: dict[str, Any] = {
         "start_match_threshold": 0.75,
         "click_delay_sec": 0.5,
         "start_delay_sec": 0.8,
+        "scroll_settle_delay_sec": 0.4,
+        "click_reverify_threshold": 0.70,
+        "max_click_reverify_retries": 2,
     },
     "auto_repeat": {
         "enabled": False,
         "count": 5,
         "dismiss_delay_sec": 0.8,
+    },
+    "vitality_detect": {
+        "enabled": True,
+        "roi": [544, 622, 184, 46],
+        "cost_pattern": "(\\d+)",
+        "min_confirm_reads": 2,
+        "confirm_interval_sec": 0.3,
+        "vitality_threshold": 1,
     },
     "keys": {
         "press_delay_sec": 0.0,

--- a/agent/custom/action/rhythm/utils/song_selector.py
+++ b/agent/custom/action/rhythm/utils/song_selector.py
@@ -83,6 +83,9 @@ class SongSelector:
         self._start_delay = float(sc.get("start_delay_sec", 0.8))
         self._start_match_threshold = float(sc.get("start_match_threshold", 0.75))
         self._max_start_retries = max(1, int(sc.get("max_start_retries", 5)))
+        self._scroll_settle_delay = float(sc.get("scroll_settle_delay_sec", 0.4))
+        self._click_reverify_threshold = float(sc.get("click_reverify_threshold", 0.70))
+        self._max_click_reverify_retries = max(1, int(sc.get("max_click_reverify_retries", 2)))
 
         self._template: NDArray[np.uint8] | None = None
         self._start_template: NDArray[np.uint8] | None = None
@@ -93,6 +96,8 @@ class SongSelector:
         self._start_retry_count: int = 0
         self._consecutive_down_fails: int = 0
         self._one_time_ds: int | None = None
+        self._post_scroll_time: float = 0.0
+        self._click_reverify_retries: int = 0
 
         self._start_template = self._load_start_template()
 
@@ -133,6 +138,8 @@ class SongSelector:
         self._start_retry_count = 0
         self._consecutive_down_fails = 0
         self._one_time_ds = None
+        self._post_scroll_time = 0.0
+        self._click_reverify_retries = 0
 
     @property
     def state(self) -> str:
@@ -154,11 +161,14 @@ class SongSelector:
             self._scroll_attempts = 0
 
         if self._state == _SEL_SEARCHING:
+            if self._scroll_attempts > 0 and now - self._post_scroll_time < self._scroll_settle_delay:
+                return {"state": self._state, "action": "settling", "scroll_attempts": self._scroll_attempts}
             match = self._find_template(frame_bgr, self._template, self._match_threshold)
             if match is not None:
                 self._match_loc = match
                 self._consecutive_down_fails = 0
                 self._one_time_ds = None
+                self._click_reverify_retries = 0
                 self._state = _SEL_CLICKING_SONG
                 logger.info(
                     "歌曲模板匹配成功: 位置=(%d,%d), 将点击选中",
@@ -193,22 +203,44 @@ class SongSelector:
                 scroll_func(sx, sy, direction)
             self._scroll_attempts += 1
             self._last_action_time = now
+            self._post_scroll_time = time.perf_counter()
             self._state = _SEL_SEARCHING
-            logger.debug("滚动搜索: 第 %d 次 (方向=%d)", self._scroll_attempts, direction)
+            logger.debug("滚动搜索: 第 %d 次 (方向=%d), 等待%.2fs稳定",
+                         self._scroll_attempts, direction, self._scroll_settle_delay)
             return {"state": self._state, "action": "scroll", "scroll_attempts": self._scroll_attempts}
 
         if self._state == _SEL_CLICKING_SONG:
             if now - self._last_action_time < self._click_delay:
                 return {"state": self._state, "action": "waiting"}
-            if self._match_loc is not None:
-                mx, my = self._match_loc
-                controller.post_click(mx, my).wait()
-                self._last_action_time = now
-                self._start_retry_count = 0
-                self._state = _SEL_CLICKING_START
-                logger.info("已点击目标歌曲位置 (%d,%d)，等待后点击开始演奏", mx, my)
-            else:
-                self._state = _SEL_SEARCHING
+            current_match = self._find_template(frame_bgr, self._template, self._click_reverify_threshold)
+            if current_match is None:
+                self._click_reverify_retries += 1
+                if self._click_reverify_retries < self._max_click_reverify_retries:
+                    logger.warning(
+                        "点击前重验证失败 (%d/%d)，歌单可能已回滚，重新搜索",
+                        self._click_reverify_retries, self._max_click_reverify_retries,
+                    )
+                    self._last_action_time = now
+                    self._post_scroll_time = 0.0
+                    self._state = _SEL_SEARCHING
+                    return {"state": self._state, "action": "reverify_fail"}
+                else:
+                    logger.warning(
+                        "重验证 %d 次均失败，回退到滚动搜索",
+                        self._click_reverify_retries,
+                    )
+                    self._click_reverify_retries = 0
+                    self._last_action_time = now
+                    self._post_scroll_time = 0.0
+                    self._state = _SEL_SEARCHING
+                    return {"state": self._state, "action": "reverify_fail"}
+            self._match_loc = current_match
+            mx, my = current_match
+            controller.post_click(mx, my).wait()
+            self._last_action_time = now
+            self._start_retry_count = 0
+            self._state = _SEL_CLICKING_START
+            logger.info("已点击目标歌曲位置 (%d,%d)，等待后点击开始演奏", mx, my)
             return {"state": self._state, "action": "click_song"}
 
         if self._state == _SEL_CLICKING_START:

--- a/assets/resource/base/pipeline/Rhythm/Rhythm.json
+++ b/assets/resource/base/pipeline/Rhythm/Rhythm.json
@@ -62,7 +62,7 @@
             "RhythmSceneOnResults"
         ],
         "next": [
-            "RhythmDismissResults"
+            "RhythmCheckVitality"
         ]
     },
     "RhythmOnSongSelect": {
@@ -73,6 +73,15 @@
         ],
         "next": [
             "RhythmSelectSong"
+        ]
+    },
+    "RhythmCheckVitality": {
+        "desc": "结算页识别消耗活力",
+        "action": "Custom",
+        "custom_action": "auto_rhythm_vitality_on_results",
+        "custom_action_param": {},
+        "next": [
+            "RhythmDismissResults"
         ]
     },
     "RhythmDismissResults": {

--- a/assets/resource/base/rhythm_config.json
+++ b/assets/resource/base/rhythm_config.json
@@ -66,12 +66,28 @@
         "match_threshold": 0.75,
         "start_match_threshold": 0.75,
         "click_delay_sec": 0.5,
-        "start_delay_sec": 0.8
+        "start_delay_sec": 0.8,
+        "scroll_settle_delay_sec": 0.4,
+        "click_reverify_threshold": 0.70,
+        "max_click_reverify_retries": 2
     },
     "auto_repeat": {
         "enabled": false,
         "count": 5,
         "dismiss_delay_sec": 0.8
+    },
+    "vitality_detect": {
+        "enabled": true,
+        "roi": [
+            544,
+            622,
+            184,
+            46
+        ],
+        "cost_pattern": "(\\d+)",
+        "min_confirm_reads": 2,
+        "confirm_interval_sec": 0.3,
+        "vitality_threshold": 1
     },
     "keys": {
         "press_delay_sec": 0.0,


### PR DESCRIPTION
### 选曲回滚修复
- 滚动后增加稳定等待(scroll_settle_delay_sec=0.4s)，避免滚动惯性导致误匹配
- 点击前重新验证模板位置(click_reverify_threshold=0.70)，歌单回滚时自动回退搜索
- 延长 swipe duration 100→250ms，减少惯性反弹

### 连打活力检测修复
- 修复 消耗活力 roi区域错误问题
- 新增 RhythmCheckVitality 步骤，在结算页(非关闭后)截图 OCR 识别消耗活力
- 多次 OCR 采样取众数确认(min_confirm_reads=2)，避免单次误判

### 场景识别优化
- 冷却锁过期后识别非 playing 立即退出，不再等待多帧确认
- 仍在 playing 时刷新冷却锁，避免误判