### PR TITLE
feat(autofish): 替换 print 为 logger 并增加进度日志

### DIFF
--- a/agent/custom/action/AutoFish/auto_buy_fish_bait.py
+++ b/agent/custom/action/AutoFish/auto_buy_fish_bait.py
@@ -63,9 +63,9 @@ class AutoBuyFishBait(CustomAction):
             find_bait_attempt += 1
             img = get_image(controller)
             found_bait, prob, x, y = match_template_in_region(img, fish_shop_region, self.bait_template, found_bait_threshold)
-            logger.debug(f"  第 {find_bait_attempt} 次尝试定位鱼饵: 匹配度={prob:.2f}, 阈值={found_bait_threshold}")
+            logger.debug(f"第 {find_bait_attempt} 次尝试定位鱼饵: 匹配度={prob:.2f}, 阈值={found_bait_threshold}")
             if found_bait:
-                logger.info(f"  鱼饵已定位 ({x+15},{y+5}), 点击中")
+                logger.info(f"鱼饵已定位 ({x+15},{y+5}), 点击中")
                 for _ in range(3):
                     click_rect(controller, [x, y, 30, 10])
                     time.sleep(0.1)
@@ -76,10 +76,10 @@ class AutoBuyFishBait(CustomAction):
                     time.sleep(0.5)
                     break
                 else:
-                    logger.warning("  鱼饵已找到但点击未生效，重试...")
+                    logger.warning("鱼饵已找到但点击未生效，重试...")
                     time.sleep(1)
             else:
-                logger.warning(f"  鱼店中未找到鱼饵 (第 {find_bait_attempt} 次)，刷新店铺后重试")
+                logger.warning(f"鱼店中未找到鱼饵 (第 {find_bait_attempt} 次)，刷新店铺后重试")
                 controller.post_click_key(KEY_R).wait()
                 time.sleep(1)
                 continue
@@ -90,16 +90,16 @@ class AutoBuyFishBait(CustomAction):
             select_max_attempt += 1
             img = get_image(controller)
             found_select_max, prob, _, _ = match_template_in_region(img, select_max_region, self.select_max_template, match_threshold)
-            logger.debug(f"  第 {select_max_attempt} 次查找“最大数量”按钮: 匹配度={prob:.2f}")
+            logger.debug(f"第 {select_max_attempt} 次查找“最大数量”按钮: 匹配度={prob:.2f}")
             if found_select_max:
-                logger.info("  已找到“最大数量”按钮，点击中")
+                logger.info("已找到“最大数量”按钮，点击中")
                 for _ in range(5):
                     click_rect(controller, select_max_region, 0.3)
                     time.sleep(0.1)
                 time.sleep(1)
                 break
             else:
-                logger.debug("  未找到“最大数量”按钮，重试...")
+                logger.debug("未找到“最大数量”按钮，重试...")
                 time.sleep(1)
 
         logger.info("步骤 3/4: 点击“购买”")
@@ -109,14 +109,14 @@ class AutoBuyFishBait(CustomAction):
             img = get_image(controller)
             found_buy, _, _, _ = match_template_in_region(img, buy_region, self.buy_template, match_threshold)
             if found_buy:
-                logger.info("  已找到“购买”按钮，点击中")
+                logger.info("已找到“购买”按钮，点击中")
                 for _ in range(3):
                     click_rect(controller, buy_region, 0.3)
                     time.sleep(0.1)
                 time.sleep(0.5)
                 break
             else:
-                logger.debug(f"  未找到“购买”按钮 (第 {buy_attempt} 次)，重试...")
+                logger.debug(f"未找到“购买”按钮 (第 {buy_attempt} 次)，重试...")
                 time.sleep(1)
 
         confirm_attempt = 0
@@ -125,14 +125,14 @@ class AutoBuyFishBait(CustomAction):
             img = get_image(controller)
             found_buy_confirm, _, _, _ = match_template_in_region(img, buy_confirm_region, self.buy_confirm_template, match_threshold)
             if found_buy_confirm:
-                logger.info("  已找到“确认购买”按钮，点击中")
+                logger.info("已找到“确认购买”按钮，点击中")
                 for _ in range(3):
                     click_rect(controller, buy_confirm_region)
                     time.sleep(0.1)
                 time.sleep(0.5)
                 break
             else:
-                logger.debug(f"  未找到“确认购买”按钮 (第 {confirm_attempt} 次)，重试...")
+                logger.debug(f"未找到“确认购买”按钮 (第 {confirm_attempt} 次)，重试...")
                 time.sleep(1)
 
         logger.info("步骤 4/4: 等待购买成功提示")
@@ -148,7 +148,7 @@ class AutoBuyFishBait(CustomAction):
                 controller.post_click_key(KEY_ESC).wait()
                 break
             else:
-                logger.debug(f"  未检测到购买成功 (第 {success_attempt} 次)，继续等待...")
+                logger.debug(f"未检测到购买成功 (第 {success_attempt} 次)，继续等待...")
                 time.sleep(1)
 
         return CustomAction.RunResult(success=True)

--- a/agent/custom/action/AutoFish/auto_buy_fish_bait.py
+++ b/agent/custom/action/AutoFish/auto_buy_fish_bait.py
@@ -4,10 +4,13 @@ import json
 
 from pathlib import Path
 from ..Common.utils import get_image, match_template_in_region, click_rect
+from ..Common.logger import get_logger
 
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
+
+logger = get_logger("auto_buy_fish_bait")
 
 
 @AgentServer.custom_action("auto_buy_fish_bait")
@@ -51,86 +54,101 @@ class AutoBuyFishBait(CustomAction):
             except:
                 pass
         
-        print("=== AutoBuyFishBait Action Started ===")
+        logger.info(f"买鱼饵流程开始 (阈值={found_bait_threshold:.2f})")
 
         match_threshold = 0.7
+        logger.info("步骤 1/4: 在鱼店中定位鱼饵")
+        find_bait_attempt = 0
         while True:
+            find_bait_attempt += 1
             img = get_image(controller)
             found_bait, prob, x, y = match_template_in_region(img, fish_shop_region, self.bait_template, found_bait_threshold)
-            print(f"Current found bait threshold: {found_bait_threshold}, match probability: {prob:.2f}, clicked on bait at ({x+15}, {y+5})")
+            logger.debug(f"  第 {find_bait_attempt} 次尝试定位鱼饵: 匹配度={prob:.2f}, 阈值={found_bait_threshold}")
             if found_bait:
+                logger.info(f"  鱼饵已定位 ({x+15},{y+5}), 点击中")
                 for _ in range(3):
                     click_rect(controller, [x, y, 30, 10])
                     time.sleep(0.1)
-                
+
                 img = get_image(controller)
                 found_bait_success, _, _, _ = match_template_in_region(img, find_bait_success_region, self.find_bait_success_template, match_threshold)
                 if found_bait_success:
                     time.sleep(0.5)
                     break
                 else:
-                    print("Bait found but not click correctly, retrying...")
+                    logger.warning("  鱼饵已找到但点击未生效，重试...")
                     time.sleep(1)
             else:
-                print("Bait not found in fish shop, retrying...")
-                controller.post_click_key(KEY_R).wait()  
+                logger.warning(f"  鱼店中未找到鱼饵 (第 {find_bait_attempt} 次)，刷新店铺后重试")
+                controller.post_click_key(KEY_R).wait()
                 time.sleep(1)
                 continue
 
+        logger.info("步骤 2/4: 选择最大购买数量")
+        select_max_attempt = 0
         while True:
+            select_max_attempt += 1
             img = get_image(controller)
             found_select_max, prob, _, _ = match_template_in_region(img, select_max_region, self.select_max_template, match_threshold)
-            print(f"Looking for select max option, match probability: {prob:.2f}")
+            logger.debug(f"  第 {select_max_attempt} 次查找“最大数量”按钮: 匹配度={prob:.2f}")
             if found_select_max:
-                print("Select max option found, clicking...")
+                logger.info("  已找到“最大数量”按钮，点击中")
                 for _ in range(5):
                     click_rect(controller, select_max_region, 0.3)
                     time.sleep(0.1)
                 time.sleep(1)
                 break
             else:
-                print("Select max option not found, retrying...")
+                logger.debug("  未找到“最大数量”按钮，重试...")
                 time.sleep(1)
-        
+
+        logger.info("步骤 3/4: 点击“购买”")
+        buy_attempt = 0
         while True:
+            buy_attempt += 1
             img = get_image(controller)
             found_buy, _, _, _ = match_template_in_region(img, buy_region, self.buy_template, match_threshold)
             if found_buy:
-                print("Buy button found, clicking...")
+                logger.info("  已找到“购买”按钮，点击中")
                 for _ in range(3):
                     click_rect(controller, buy_region, 0.3)
                     time.sleep(0.1)
                 time.sleep(0.5)
                 break
             else:
-                print("Buy button not found, retrying...")
+                logger.debug(f"  未找到“购买”按钮 (第 {buy_attempt} 次)，重试...")
                 time.sleep(1)
 
+        confirm_attempt = 0
         for _ in range(5):
+            confirm_attempt += 1
             img = get_image(controller)
             found_buy_confirm, _, _, _ = match_template_in_region(img, buy_confirm_region, self.buy_confirm_template, match_threshold)
             if found_buy_confirm:
-                print("Buy confirm button found, clicking...")
+                logger.info("  已找到“确认购买”按钮，点击中")
                 for _ in range(3):
                     click_rect(controller, buy_confirm_region)
                     time.sleep(0.1)
                 time.sleep(0.5)
                 break
             else:
-                print("Buy confirm button not found, retrying...")
+                logger.debug(f"  未找到“确认购买”按钮 (第 {confirm_attempt} 次)，重试...")
                 time.sleep(1)
 
+        logger.info("步骤 4/4: 等待购买成功提示")
+        success_attempt = 0
         while True:
+            success_attempt += 1
             img = get_image(controller)
             found_buy_success, _, _, _ = match_template_in_region(img, buy_success_region, self.buy_success_template, match_threshold)
             if found_buy_success:
-                print("Buy success.")
+                logger.info("买鱼饵成功，关闭店铺")
                 controller.post_click_key(KEY_ESC).wait()
                 time.sleep(0.5)
                 controller.post_click_key(KEY_ESC).wait()
                 break
             else:
-                print("Buy success confirmation not found, retrying...")
-                time.sleep(1)                
+                logger.debug(f"  未检测到购买成功 (第 {success_attempt} 次)，继续等待...")
+                time.sleep(1)
 
         return CustomAction.RunResult(success=True)

--- a/agent/custom/action/AutoFish/auto_fish.py
+++ b/agent/custom/action/AutoFish/auto_fish.py
@@ -96,26 +96,26 @@ class AutoFish(CustomAction):
 
                 m_settle, _, _, _ = match_template_in_region(img, settlement_region, self.settlement_template, 0.8)
                 if m_settle:
-                    logger.info("  检查阶段检测到结算页，按 ESC 关闭")
+                    logger.info("检查阶段检测到结算页，按 ESC 关闭")
                     press_esc()
                     wait_until_settlement_disappears()
                     continue
 
                 m_game, game_prob, _, _ = match_template_in_region(img, fish_game_sign_region_2, self.fish_game_sign_template, 0.6, green_mask=True)
-                logger.debug(f"  第 {attempt}/10 次检测钓鱼小游戏: 匹配度={game_prob:.2f}")
+                logger.debug(f"第 {attempt}/10 次检测钓鱼小游戏: 匹配度={game_prob:.2f}")
                 if m_game:
                     return True
 
                 m_prepare, _, x, y = match_template_in_region(img, prepare_region, self.prepare_start_template, 0.7)
                 if m_prepare:
-                    logger.info("  位于钓鱼准备界面，点击开始")
+                    logger.info("位于钓鱼准备界面，点击开始")
                     controller.post_click(x + 15, y + 15)
                     time.sleep(1.5)
                     return True
 
                 time.sleep(0.1)
 
-            logger.error("  10 次检测后仍未进入钓鱼小游戏或准备界面，退出本次钓鱼")
+            logger.error("10 次检测后仍未进入钓鱼小游戏或准备界面，退出本次钓鱼")
             return False
 
         for i in range(fishing_count):
@@ -131,7 +131,7 @@ class AutoFish(CustomAction):
                 if context.tasker.stopping:
                     return CustomAction.RunResult(success=False)
                 cast_n += 1
-                logger.info(f"  [循环 {i + 1}/{fishing_count}] 第 {cast_n} 次抛竿尝试")
+                logger.info(f"[循环 {i + 1}/{fishing_count}] 第 {cast_n} 次抛竿尝试")
                 for _ in range(5):
                     controller.post_key_down(KEY_F)
                     time.sleep(0.1)
@@ -140,14 +140,14 @@ class AutoFish(CustomAction):
                 for bait_check_n in range(1, 6):
                     img = get_image(controller)
                     m_need_bait, prob, _, _ = match_template_in_region(img, need_bait_region, self.need_bait_template, 0.7)
-                    logger.debug(f"  第 {bait_check_n}/5 次检查鱼饵: 匹配度={prob:.2f}")
+                    logger.debug(f"第 {bait_check_n}/5 次检查鱼饵: 匹配度={prob:.2f}")
                     if m_need_bait:
-                        logger.error("  鱼饵不足，停止钓鱼")
+                        logger.error("鱼饵不足，停止钓鱼")
                         return CustomAction.RunResult(success=False)
 
                     time.sleep(0.1)
 
-                logger.info("  抛竿中...")
+                logger.info("抛竿中...")
 
                 wait_start = time.time()
                 m_settle_unexpected = False
@@ -158,7 +158,7 @@ class AutoFish(CustomAction):
                         return CustomAction.RunResult(success=False)
 
                     if time.time() - wait_start > 30:
-                        logger.warning("  等待鱼上钩超时 (30s)，重新抛竿")
+                        logger.warning("等待鱼上钩超时 (30s)，重新抛竿")
                         timeout_triggered = True
                         break
 
@@ -167,7 +167,7 @@ class AutoFish(CustomAction):
 
                     m_settle_unexpected, _, _, _ = match_template_in_region(img, settlement_region, self.settlement_template, 0.8)
                     if m_settle_unexpected:
-                        logger.warning("  等待上钩时检测到结算页，清理后重试")
+                        logger.warning("等待上钩时检测到结算页，清理后重试")
                         break
 
                     m_catch, _, _, _ = match_template_in_region(img, success_region, self.success_catch_template, 0.7)
@@ -175,7 +175,7 @@ class AutoFish(CustomAction):
                         controller.post_key_down(KEY_F)
                         time.sleep(0.1)
                         controller.post_key_up(KEY_F)
-                        logger.info(f"  鱼已上钩！(等待 {time.time() - wait_start:.1f}s)")
+                        logger.info(f"鱼已上钩！(等待 {time.time() - wait_start:.1f}s)")
                         break
                 
                 if m_settle_unexpected or timeout_triggered:
@@ -214,11 +214,11 @@ class AutoFish(CustomAction):
                     if frame % 10 == 0:
                         m_settle, _, _, _ = match_template_in_region(img, settlement_region, self.settlement_template, 0.8)
                         if m_settle:
-                            logger.info(f"  鱼已钓上！(控条 {frame} 帧, {time.time() - start_time:.1f}s)")
+                            logger.info(f"鱼已钓上！(控条 {frame} 帧, {time.time() - start_time:.1f}s)")
                             break
                         m_escape, _, _, _ = match_template_in_region(img, escape_region, self.escape_template, 0.8)
                         if m_escape:
-                            logger.warning(f"  鱼脱钩，重新抛竿 (控条 {frame} 帧)")
+                            logger.warning(f"鱼脱钩，重新抛竿 (控条 {frame} 帧)")
                             break
 
                     m_left, _, x_left, _ = match_template_in_region(img, game_region, self.valid_region_left_template, 0.7)
@@ -281,7 +281,7 @@ class AutoFish(CustomAction):
                     continue  
                 break  
 
-            logger.info(f"  本次钓鱼完成 (共 {cast_n} 次抛竿尝试)")
+            logger.info(f"本次钓鱼完成 (共 {cast_n} 次抛竿尝试)")
 
             match_settle = False
             wait_settlement_start = time.time()
@@ -293,21 +293,21 @@ class AutoFish(CustomAction):
                 settle_check_n += 1
                 img = get_image(controller)
                 match_settle, settle_prob, _, _ = match_template_in_region(img, settlement_region, self.settlement_template, 0.8)
-                logger.debug(f"  第 {settle_check_n} 次检测结算页: 匹配度={settle_prob:.2f}")
+                logger.debug(f"第 {settle_check_n} 次检测结算页: 匹配度={settle_prob:.2f}")
                 if match_settle:
-                    logger.info("  检测到结算页")
+                    logger.info("检测到结算页")
                     break
                 time.sleep(0.05)
 
             if match_settle:
-                logger.info("  关闭结算页...")
+                logger.info("关闭结算页...")
                 for _ in range(5):
                     press_esc()
                     if wait_until_settlement_disappears():
-                        logger.info("  结算页已关闭")
+                        logger.info("结算页已关闭")
                         break
             else:
-                logger.warning("  未检测到结算页，直接继续下一次")
+                logger.warning("未检测到结算页，直接继续下一次")
 
         logger.info(f"全部钓鱼任务完成 (共 {fishing_count} 次)")
         return CustomAction.RunResult(success=True)

--- a/agent/custom/action/AutoFish/auto_fish.py
+++ b/agent/custom/action/AutoFish/auto_fish.py
@@ -4,10 +4,13 @@ import json
 
 from pathlib import Path
 from ..Common.utils import get_image, match_template_in_region
+from ..Common.logger import get_logger
 
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
+
+logger = get_logger("auto_fish")
 
 
 @AgentServer.custom_action("auto_fish")
@@ -38,7 +41,7 @@ class AutoFish(CustomAction):
     need_bait_template = cv2.imread(str(need_bait_img), cv2.IMREAD_COLOR)
 
     def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
-        print("=== Autofish Action Started ===")
+        logger.info("钓鱼动作开始 (auto_fish)")
         controller = context.tasker.controller
 
         fishing_count = 10
@@ -50,6 +53,8 @@ class AutoFish(CustomAction):
                 check_freq = params.get("freq", 0.001)
             except:
                 pass
+
+        logger.info(f"钓鱼参数: 总次数={fishing_count}, 检测频率={check_freq}s")
    
         KEY_A = 65
         KEY_D = 68
@@ -86,60 +91,63 @@ class AutoFish(CustomAction):
             return False
 
         def ensure_fish_game():
-            for _ in range(10):
+            for attempt in range(1, 11):
                 img = get_image(controller)
-                
+
                 m_settle, _, _, _ = match_template_in_region(img, settlement_region, self.settlement_template, 0.8)
                 if m_settle:
-                    print("  Found settlement screen during check, pressing ESC to close...")
+                    logger.info("  检查阶段检测到结算页，按 ESC 关闭")
                     press_esc()
                     wait_until_settlement_disappears()
                     continue
 
                 m_game, game_prob, _, _ = match_template_in_region(img, fish_game_sign_region_2, self.fish_game_sign_template, 0.6, green_mask=True)
-                print(f"  Checking for FishGame screen, probability: {game_prob:.2f}")
+                logger.debug(f"  第 {attempt}/10 次检测钓鱼小游戏: 匹配度={game_prob:.2f}")
                 if m_game:
                     return True
 
                 m_prepare, _, x, y = match_template_in_region(img, prepare_region, self.prepare_start_template, 0.7)
                 if m_prepare:
-                    print("  On FishPrepare screen, pressing start...")
+                    logger.info("  位于钓鱼准备界面，点击开始")
                     controller.post_click(x + 15, y + 15)
                     time.sleep(1.5)
                     return True
-                
+
                 time.sleep(0.1)
 
-            print("  ERROR: Not in FishGame or FishPrepare, exiting fishing.")
-            return False  
+            logger.error("  10 次检测后仍未进入钓鱼小游戏或准备界面，退出本次钓鱼")
+            return False
 
         for i in range(fishing_count):
             if context.tasker.stopping:
                 return CustomAction.RunResult(success=False)
-            print(f"=== Fishing {i + 1}/{fishing_count} ===")
+            logger.info(f"=== 第 {i + 1}/{fishing_count} 次钓鱼 ===")
 
             if not ensure_fish_game():
                 return CustomAction.RunResult(success=False)
 
+            cast_n = 0
             while True:
                 if context.tasker.stopping:
                     return CustomAction.RunResult(success=False)
+                cast_n += 1
+                logger.info(f"  [循环 {i + 1}/{fishing_count}] 第 {cast_n} 次抛竿尝试")
                 for _ in range(5):
                     controller.post_key_down(KEY_F)
                     time.sleep(0.1)
                     controller.post_key_up(KEY_F)
 
-                for _ in range(5):
+                for bait_check_n in range(1, 6):
                     img = get_image(controller)
                     m_need_bait, prob, _, _ = match_template_in_region(img, need_bait_region, self.need_bait_template, 0.7)
-                    print(f"  Checking for bait, probability: {prob:.2f}")
+                    logger.debug(f"  第 {bait_check_n}/5 次检查鱼饵: 匹配度={prob:.2f}")
                     if m_need_bait:
-                        print("  Need bait! Stopping fishing.")
+                        logger.error("  鱼饵不足，停止钓鱼")
                         return CustomAction.RunResult(success=False)
-                    
+
                     time.sleep(0.1)
-                
-                print("  Casting...")
+
+                logger.info("  抛竿中...")
 
                 wait_start = time.time()
                 m_settle_unexpected = False
@@ -148,18 +156,18 @@ class AutoFish(CustomAction):
                 while True:
                     if context.tasker.stopping:
                         return CustomAction.RunResult(success=False)
-                        
+
                     if time.time() - wait_start > 30:
-                        print("  Timeout waiting for fish to hook, recasting...")
+                        logger.warning("  等待鱼上钩超时 (30s)，重新抛竿")
                         timeout_triggered = True
                         break
-                        
+
                     time.sleep(check_freq)
                     img = get_image(controller)
-                    
+
                     m_settle_unexpected, _, _, _ = match_template_in_region(img, settlement_region, self.settlement_template, 0.8)
                     if m_settle_unexpected:
-                        print("  Unexpected settlement screen detected! Breaking to clear it.")
+                        logger.warning("  等待上钩时检测到结算页，清理后重试")
                         break
 
                     m_catch, _, _, _ = match_template_in_region(img, success_region, self.success_catch_template, 0.7)
@@ -167,7 +175,7 @@ class AutoFish(CustomAction):
                         controller.post_key_down(KEY_F)
                         time.sleep(0.1)
                         controller.post_key_up(KEY_F)
-                        print("  Fish hooked!")
+                        logger.info(f"  鱼已上钩！(等待 {time.time() - wait_start:.1f}s)")
                         break
                 
                 if m_settle_unexpected or timeout_triggered:
@@ -206,11 +214,11 @@ class AutoFish(CustomAction):
                     if frame % 10 == 0:
                         m_settle, _, _, _ = match_template_in_region(img, settlement_region, self.settlement_template, 0.8)
                         if m_settle:
-                            print("  Fish caught!")
+                            logger.info(f"  鱼已钓上！(控条 {frame} 帧, {time.time() - start_time:.1f}s)")
                             break
                         m_escape, _, _, _ = match_template_in_region(img, escape_region, self.escape_template, 0.8)
                         if m_escape:
-                            print("  Fish escaped! Recasting...")
+                            logger.warning(f"  鱼脱钩，重新抛竿 (控条 {frame} 帧)")
                             break
 
                     m_left, _, x_left, _ = match_template_in_region(img, game_region, self.valid_region_left_template, 0.7)
@@ -273,31 +281,33 @@ class AutoFish(CustomAction):
                     continue  
                 break  
 
-            print("  Finished.")
+            logger.info(f"  本次钓鱼完成 (共 {cast_n} 次抛竿尝试)")
 
             match_settle = False
             wait_settlement_start = time.time()
+            settle_check_n = 0
             while time.time() - wait_settlement_start < 5:
                 if context.tasker.stopping:
                     return CustomAction.RunResult(success=False)
 
+                settle_check_n += 1
                 img = get_image(controller)
                 match_settle, settle_prob, _, _ = match_template_in_region(img, settlement_region, self.settlement_template, 0.8)
-                print(f"  Checking for settlement screen, probability: {settle_prob:.2f}")
+                logger.debug(f"  第 {settle_check_n} 次检测结算页: 匹配度={settle_prob:.2f}")
                 if match_settle:
-                    print("  Settlement screen detected.")
+                    logger.info("  检测到结算页")
                     break
                 time.sleep(0.05)
 
             if match_settle:
-                print("  Closing settlement screen...")
+                logger.info("  关闭结算页...")
                 for _ in range(5):
                     press_esc()
                     if wait_until_settlement_disappears():
-                        print("  Settlement closed.")
+                        logger.info("  结算页已关闭")
                         break
             else:
-                print("  Settlement screen not detected, continuing immediately.")
+                logger.warning("  未检测到结算页，直接继续下一次")
 
-        print("All fishing tasks complete.")
+        logger.info(f"全部钓鱼任务完成 (共 {fishing_count} 次)")
         return CustomAction.RunResult(success=True)

--- a/agent/custom/action/AutoFish/auto_fish_new.py
+++ b/agent/custom/action/AutoFish/auto_fish_new.py
@@ -61,13 +61,13 @@ class AutoFishNew(CustomAction):
                 img, success_region, self.success_catch_template, 0.7
             )
             if wait_frame > 300:
-                logger.warning(f"  等待鱼上钩超时 (f={wait_frame})，结束本次钓鱼")
+                logger.warning(f"等待鱼上钩超时 (f={wait_frame})，结束本次钓鱼")
                 break
             if m_catch:
                 controller.post_key_down(KEY_F)
                 time.sleep(0.1)
                 controller.post_key_up(KEY_F)
-                logger.info(f"  鱼已上钩！(f={wait_frame}, score={catch_score:.3f})")
+                logger.info(f"鱼已上钩！(f={wait_frame}, score={catch_score:.3f})")
                 break
 
         logger.info("阶段 2/2: 进入控条小游戏")
@@ -128,7 +128,7 @@ class AutoFishNew(CustomAction):
                     set_ad_key(None)
                     controller.post_key_up(KEY_F)
                     logger.info(
-                        f"  滑块连续 {slider_miss_count} 帧丢失，本次钓鱼结束 (success)"
+                        f"滑块连续 {slider_miss_count} 帧丢失，本次钓鱼结束 (success)"
                     )
                     return CustomAction.RunResult(success=True)
                 x_slider = last_x_slider
@@ -138,7 +138,7 @@ class AutoFishNew(CustomAction):
                 controller.post_key_up(KEY_A)
                 controller.post_key_up(KEY_D)
                 controller.post_key_up(KEY_F)
-                logger.warning(f"  控条阶段超时 (f={frame})，本次钓鱼结束 (failure)")
+                logger.warning(f"控条阶段超时 (f={frame})，本次钓鱼结束 (failure)")
                 return CustomAction.RunResult(success=False)
 
             if m_left and m_right:
@@ -166,7 +166,7 @@ class AutoFishNew(CustomAction):
             if frame % 30 == 0 or current_ad_key != prev_key:
                 key_name = {None: "-", KEY_A: "A", KEY_D: "D"}.get(current_ad_key, "?")
                 logger.debug(
-                    f"  f={frame} slider(x={x_slider:.0f} s={slider_score:.2f}) "
+                    f"f={frame} slider(x={x_slider:.0f} s={slider_score:.2f}) "
                     f"L({m_left} s={left_score:.2f}) R({m_right} s={right_score:.2f}) "
                     f"bar_w={last_bar_width:.0f} target={target:.0f} offset={offset:+.0f} key={key_name}"
                 )

--- a/agent/custom/action/AutoFish/auto_fish_new.py
+++ b/agent/custom/action/AutoFish/auto_fish_new.py
@@ -3,10 +3,13 @@ import time
 
 from pathlib import Path
 from ..Common.utils import get_image, match_template_in_region
+from ..Common.logger import get_logger
 
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
+
+logger = get_logger("auto_fish_new")
 
 
 @AgentServer.custom_action("auto_fish_new")
@@ -33,7 +36,7 @@ class AutoFishNew(CustomAction):
     def run(
         self, context: Context, _argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
-        print("=== Autofish Action Started ===")
+        logger.info("钓鱼动作开始 (auto_fish_new)")
         controller = context.tasker.controller
 
         KEY_A = 65
@@ -44,7 +47,7 @@ class AutoFishNew(CustomAction):
         game_region = [395, 40, 490, 20]
         deadzone = 15
 
-        print("  Casting...")
+        logger.info("阶段 1/2: 抛竿后等待鱼上钩")
 
         # --- 等待鱼上钩 ---
         wait_frame = 0
@@ -58,14 +61,16 @@ class AutoFishNew(CustomAction):
                 img, success_region, self.success_catch_template, 0.7
             )
             if wait_frame > 300:
-                print(f"  [Fish] cast timeout (f={wait_frame}), fish ended")
+                logger.warning(f"  等待鱼上钩超时 (f={wait_frame})，结束本次钓鱼")
                 break
             if m_catch:
                 controller.post_key_down(KEY_F)
                 time.sleep(0.1)
                 controller.post_key_up(KEY_F)
-                print(f"  Fish hooked! (score={catch_score:.3f})")
+                logger.info(f"  鱼已上钩！(f={wait_frame}, score={catch_score:.3f})")
                 break
+
+        logger.info("阶段 2/2: 进入控条小游戏")
 
         # --- 小游戏 ---
         frame = 0
@@ -122,8 +127,8 @@ class AutoFishNew(CustomAction):
                 if slider_miss_count >= 30:
                     set_ad_key(None)
                     controller.post_key_up(KEY_F)
-                    print(
-                        f"  [Fish] slider lost {slider_miss_count} frames, fish ended."
+                    logger.info(
+                        f"  滑块连续 {slider_miss_count} 帧丢失，本次钓鱼结束 (success)"
                     )
                     return CustomAction.RunResult(success=True)
                 x_slider = last_x_slider
@@ -133,7 +138,7 @@ class AutoFishNew(CustomAction):
                 controller.post_key_up(KEY_A)
                 controller.post_key_up(KEY_D)
                 controller.post_key_up(KEY_F)
-                print(f"  [Fish] fish timeout (f={frame}), fish ended.")
+                logger.warning(f"  控条阶段超时 (f={frame})，本次钓鱼结束 (failure)")
                 return CustomAction.RunResult(success=False)
 
             if m_left and m_right:
@@ -160,8 +165,8 @@ class AutoFishNew(CustomAction):
 
             if frame % 30 == 0 or current_ad_key != prev_key:
                 key_name = {None: "-", KEY_A: "A", KEY_D: "D"}.get(current_ad_key, "?")
-                print(
-                    f"  [Fish] f={frame} slider(x={x_slider:.0f} s={slider_score:.2f}) "
+                logger.debug(
+                    f"  f={frame} slider(x={x_slider:.0f} s={slider_score:.2f}) "
                     f"L({m_left} s={left_score:.2f}) R({m_right} s={right_score:.2f}) "
                     f"bar_w={last_bar_width:.0f} target={target:.0f} offset={offset:+.0f} key={key_name}"
                 )

--- a/agent/custom/action/AutoFish/auto_sell_fish.py
+++ b/agent/custom/action/AutoFish/auto_sell_fish.py
@@ -3,10 +3,13 @@ import time
 
 from pathlib import Path
 from ..Common.utils import get_image, match_template_in_region, click_rect
+from ..Common.logger import get_logger
 
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
+
+logger = get_logger("auto_sell_fish")
 
 
 @AgentServer.custom_action("auto_sell_fish")
@@ -33,7 +36,7 @@ class AutoSellFish(CustomAction):
     sell_fail_template = cv2.imread(str(sell_fail_img), cv2.IMREAD_COLOR)
 
     def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
-        print("=== Autofish Action Started ===")
+        logger.info("卖鱼流程开始")
         controller = context.tasker.controller
 
         KEY_Q = 81
@@ -48,73 +51,88 @@ class AutoSellFish(CustomAction):
         sell_fail_region = [739, 349, 202, 24]
         no_valid_fish_region = [509, 350, 261, 22]
         
+        logger.info("步骤 1/3: 切换到卖鱼选项")
+        sell_option_attempt = 0
         while True:
+            sell_option_attempt += 1
             img = get_image(controller)
             found_sell_option, _, _, _ = match_template_in_region(img, sell_option_region, self.sell_option_template, 0.7)
             if found_sell_option:
                 for _ in range(3):
                     click_rect(controller, sell_option_region)
                     time.sleep(0.1)
-                
+
                 img = get_image(controller)
                 found_sell_option_selected, _, _, _ = match_template_in_region(img, sell_option_selected_region, self.sell_option_selected_template, 0.8)
                 if found_sell_option_selected:
                     break
-                time.sleep(1)  
+                time.sleep(1)
             else:
-                controller.post_click_key(KEY_Q).wait()  
-                time.sleep(1)  
+                logger.debug(f"  未找到卖鱼选项 (第 {sell_option_attempt} 次)，按 Q 后重试")
+                controller.post_click_key(KEY_Q).wait()
+                time.sleep(1)
 
-        print("Sell option detected. Proceeding to sell fish.")
+        logger.info("已进入卖鱼界面")
 
-        for _ in range(5):
+        logger.info("步骤 2/3: 检查是否有可卖鱼")
+        for check_n in range(1, 6):
             img = get_image(controller)
             found_no_fish_to_sell, prob, _, _ = match_template_in_region(img, no_fish_to_sell_region, self.no_fish_to_sell_template, 0.8)
+            logger.debug(f"  第 {check_n}/5 次检查“无鱼可卖”: 匹配度={prob:.2f}")
             time.sleep(0.1)
             if found_no_fish_to_sell:
-                print("No fish to sell detected. Closing fish shop.")
-                controller.post_click_key(KEY_ESC).wait()  
+                logger.info("无鱼可卖，关闭店铺")
+                controller.post_click_key(KEY_ESC).wait()
                 return CustomAction.RunResult(success=True)
-        
+
         time.sleep(1.5)
-        
+
+        logger.info("步骤 3/3: 卖出当前鱼")
+        sell_button_attempt = 0
         while True:
+            sell_button_attempt += 1
             img = get_image(controller)
             found_sell_button, _, _, _ = match_template_in_region(img, sell_button_region, self.sell_button_template, 0.8)
             if found_sell_button:
-                print("Sell button detected. Clicking to confirm selling fish.")
+                logger.info("  已找到“卖出”按钮，点击中")
+                confirm_attempt = 0
                 while True:
+                    confirm_attempt += 1
                     click_rect(controller, sell_button_region, 0.1)
                     time.sleep(0.5)
                     img = get_image(controller)
                     found_confirm_sell, _, _, _ = match_template_in_region(img, confirm_sell_region, self.confirm_sell_template, 0.8)
                     sell_fail, _, _, _ = match_template_in_region(img, sell_fail_region, self.sell_fail_template, 0.8)
                     if found_confirm_sell:
-                        print("Confirm sell button detected. Clicking to confirm selling fish.")
+                        logger.info(f"  已找到“确认卖出”按钮 (第 {confirm_attempt} 次)，确认中")
                         click_rect(controller, confirm_sell_region, 0.2)
-                        time.sleep(0.5) 
+                        time.sleep(0.5)
                         break
                     elif sell_fail:
-                        print("no fish to sell, closing fish shop.")
+                        logger.info("无鱼可卖，关闭店铺")
                         controller.post_click_key(KEY_ESC).wait()
                         return CustomAction.RunResult(success=True)
                     else:
                         time.sleep(0.1)
                 break
             else:
+                logger.debug(f"  未找到“卖出”按钮 (第 {sell_button_attempt} 次)")
                 time.sleep(0.1)
 
+        success_attempt = 0
         while True:
+            success_attempt += 1
             img = get_image(controller)
             found_sell_success, _, _, _ = match_template_in_region(img, sell_success_region, self.sell_success_template, 0.8)
             if found_sell_success:
-                print("Sell success detected. Fish sold successfully.")
-                controller.post_click_key(KEY_ESC).wait()  
+                logger.info("卖鱼成功，关闭店铺")
+                controller.post_click_key(KEY_ESC).wait()
                 time.sleep(0.5)
                 controller.post_click_key(KEY_ESC).wait()
                 break
             else:
+                logger.debug(f"  未检测到卖出成功 (第 {success_attempt} 次)，继续等待...")
                 time.sleep(1)
-        
-        print("All fishing tasks complete.")
+
+        logger.info("卖鱼流程完成")
         return CustomAction.RunResult(success=True)

--- a/agent/custom/action/AutoFish/auto_sell_fish.py
+++ b/agent/custom/action/AutoFish/auto_sell_fish.py
@@ -68,7 +68,7 @@ class AutoSellFish(CustomAction):
                     break
                 time.sleep(1)
             else:
-                logger.debug(f"  未找到卖鱼选项 (第 {sell_option_attempt} 次)，按 Q 后重试")
+                logger.debug(f"未找到卖鱼选项 (第 {sell_option_attempt} 次)，按 Q 后重试")
                 controller.post_click_key(KEY_Q).wait()
                 time.sleep(1)
 
@@ -78,7 +78,7 @@ class AutoSellFish(CustomAction):
         for check_n in range(1, 6):
             img = get_image(controller)
             found_no_fish_to_sell, prob, _, _ = match_template_in_region(img, no_fish_to_sell_region, self.no_fish_to_sell_template, 0.8)
-            logger.debug(f"  第 {check_n}/5 次检查“无鱼可卖”: 匹配度={prob:.2f}")
+            logger.debug(f"第 {check_n}/5 次检查“无鱼可卖”: 匹配度={prob:.2f}")
             time.sleep(0.1)
             if found_no_fish_to_sell:
                 logger.info("无鱼可卖，关闭店铺")
@@ -94,7 +94,7 @@ class AutoSellFish(CustomAction):
             img = get_image(controller)
             found_sell_button, _, _, _ = match_template_in_region(img, sell_button_region, self.sell_button_template, 0.8)
             if found_sell_button:
-                logger.info("  已找到“卖出”按钮，点击中")
+                logger.info("已找到“卖出”按钮，点击中")
                 confirm_attempt = 0
                 while True:
                     confirm_attempt += 1
@@ -104,7 +104,7 @@ class AutoSellFish(CustomAction):
                     found_confirm_sell, _, _, _ = match_template_in_region(img, confirm_sell_region, self.confirm_sell_template, 0.8)
                     sell_fail, _, _, _ = match_template_in_region(img, sell_fail_region, self.sell_fail_template, 0.8)
                     if found_confirm_sell:
-                        logger.info(f"  已找到“确认卖出”按钮 (第 {confirm_attempt} 次)，确认中")
+                        logger.info(f"已找到“确认卖出”按钮 (第 {confirm_attempt} 次)，确认中")
                         click_rect(controller, confirm_sell_region, 0.2)
                         time.sleep(0.5)
                         break
@@ -116,7 +116,7 @@ class AutoSellFish(CustomAction):
                         time.sleep(0.1)
                 break
             else:
-                logger.debug(f"  未找到“卖出”按钮 (第 {sell_button_attempt} 次)")
+                logger.debug(f"未找到“卖出”按钮 (第 {sell_button_attempt} 次)")
                 time.sleep(0.1)
 
         success_attempt = 0
@@ -131,7 +131,7 @@ class AutoSellFish(CustomAction):
                 controller.post_click_key(KEY_ESC).wait()
                 break
             else:
-                logger.debug(f"  未检测到卖出成功 (第 {success_attempt} 次)，继续等待...")
+                logger.debug(f"未检测到卖出成功 (第 {success_attempt} 次)，继续等待...")
                 time.sleep(1)
 
         logger.info("卖鱼流程完成")


### PR DESCRIPTION
## 关联 Issue
Resolves #97

## 改动概览
将 4 个 AutoFish 动作从 `print()` 切换到 `Common.logger.get_logger`，与已有的
`auto_fish_withoutCV.py` 保持一致：

- `auto_fish.py` (21 print → logger)
- `auto_fish_new.py` (7 print → logger)
- `auto_buy_fish_bait.py` (13 print → logger)
- `auto_sell_fish.py` (8 print → logger)

## 可观测性改进（响应 #97 的具体诉求）
- **抛竿计数**：`auto_fish.py` 内层重新抛竿循环新增 `cast_n` 计数，输出
  `[循环 i/total] 第 cast_n 次抛竿尝试`
- **阶段标记**：买/卖鱼饵流程加上 `步骤 1/4`、`步骤 2/4` 等阶段头
- **探测进度**：模板匹配/重试循环输出 `第 N 次尝试: 匹配度=...`
- **关键事件耗时**：鱼上钩、控条结束等输出耗时/帧数

## 日志等级
- `info`：流程里程碑、阶段切换
- `debug`：高频探测（默认不显示，需要诊断时开 DEBUG）
- `warning`：可恢复异常（超时重试、鱼脱钩、未匹配重试）
- `error`：致命错误（鱼饵不足、未进入钓鱼小游戏）

## 测试
- `python -m py_compile agent/custom/action/AutoFish/*.py` 通过
- 不修改任何控制流，仅替换日志输出

## 后续
`auto_make_coffee.py` 和 `realtime_task.py` 仍使用 `print()`，可在后续 PR 中
统一处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

将 AutoFish 操作中基于 `print` 的输出替换为结构化日志，并为钓鱼、购买鱼饵和卖鱼流程添加详细的进度与状态监控。

Enhancements:
- 将与 AutoFish 相关的操作统一为使用共享日志记录器，而非直接使用 `print` 语句。
- 为钓鱼、购买鱼饵和卖鱼流程添加更细粒度的进度、尝试次数计数器以及时间日志，以提升可观测性和故障排查能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace print-based output in AutoFish actions with structured logging and enrich fishing, buying bait, and selling flows with detailed progress and status instrumentation.

Enhancements:
- Standardize AutoFish-related actions to use the shared logger instead of direct print statements.
- Add granular progress, attempt counters, and timing logs for fishing, bait purchasing, and fish selling flows to improve observability and troubleshooting.

</details>