### PR TITLE
feat(rhythm): 优化节奏游戏场景检测和歌曲选择逻辑

### DIFF
--- a/agent/custom/action/rhythm/feats/play.py
+++ b/agent/custom/action/rhythm/feats/play.py
@@ -15,6 +15,7 @@ from ..utils.config import load_rhythm_config
 from ..utils.lanes import build_lane_layout, LaneLayout
 from ..utils.detector import DrumDetector
 from ..utils.assets import list_scene_templates, read_image
+from ..utils.presence import SceneGate, STATE_PLAYING
 
 
 logger = logging.getLogger(__name__)
@@ -105,6 +106,8 @@ class AutoRhythmPlay(CustomAction):
         if not drum_available:
             logger.warning("鼓面模板缺失，演奏检测不可用")
 
+        scene_gate = SceneGate(cfg)
+
         logger.info(
             "演奏开始 | FPS=%d | 鼓面检测=%s | 场景冷却=%.1fs(音符命中重置)",
             target_fps, drum_available, scene_lock_sec,
@@ -158,6 +161,13 @@ class AutoRhythmPlay(CustomAction):
                     _press_keys(controller, triggered_lanes, key_hold_sec)
 
             if now >= scene_lock_until:
+                gate_state, _ = scene_gate.step(frame)
+                if gate_state != STATE_PLAYING:
+                    logger.info(
+                        "演奏结束 (帧#%d, 耗时%.1f秒, 冷却锁过期，场景识别=%s)",
+                        frame_count, elapsed_total, gate_state,
+                    )
+                    return CustomAction.RunResult(success=True)
                 if not _is_still_playing(frame, playing_tpl):
                     logger.info(
                         "演奏结束 (帧#%d, 耗时%.1f秒, 冷却锁过期，识别为非playing)",

--- a/agent/custom/action/rhythm/feats/repeat_decision.py
+++ b/agent/custom/action/rhythm/feats/repeat_decision.py
@@ -217,6 +217,6 @@ class AutoRhythmRepeatDecision(CustomAction):
             _vitality_cost = None
             context.override_next("RhythmRepeatCheck", ["RhythmExit"])
         else:
-            context.override_next("RhythmRepeatCheck", ["[Anchor]RhythmLoopPoint"])
+            context.override_next("RhythmRepeatCheck", ["RhythmSelectSong"])
 
         return CustomAction.RunResult(success=True)

--- a/agent/custom/action/rhythm/utils/config.py
+++ b/agent/custom/action/rhythm/utils/config.py
@@ -32,12 +32,29 @@ _DEFAULT_CONFIG: dict[str, Any] = {
         "playing_match_threshold": 0.75,
         "match_vote_min": 1,
         "playing_check_interval": 5,
-        "scene_lock_timeout_sec": 1.5,
         "song_select_to_playing_lock_sec": 8.0,
+        "template_roi": {
+            "song_select": {
+                "logo": [0, 0, 80, 80],
+                "level": [1013, 184, 87, 58],
+                "start": [925, 641, 279, 44]
+            },
+            "playing": {
+                "pause": [0, 0, 96, 96],
+                "rate": [1076, 0, 95, 171],
+                "score": [1076, 0, 95, 171]
+            },
+            "results": {
+                "max_combo": [241, 496, 800, 70],
+                "rate": [241, 496, 800, 70],
+                "score": [241, 496, 800, 70]
+            }
+        },
     },
     "song_select": {
         "enabled": False,
         "song_name": "",
+        "song_list_roi": [47, 117, 550, 510],
         "scroll_area_x_frac": 0.25,
         "scroll_area_y_frac": 0.50,
         "scroll_delta": -1,

--- a/agent/custom/action/rhythm/utils/presence.py
+++ b/agent/custom/action/rhythm/utils/presence.py
@@ -48,6 +48,14 @@ class SceneGate:
         self._match_vote_min = max(1, int(sc.get("match_vote_min", 1)))
         self._playing_check_interval = max(1, int(sc.get("playing_check_interval", 5)))
 
+        template_roi_cfg = sc.get("template_roi") or {}
+        self._template_roi: dict[str, dict[str, tuple[int, int, int, int]]] = {}
+        for kind, name_map in template_roi_cfg.items():
+            self._template_roi[kind] = {}
+            for name, roi_list in name_map.items():
+                if isinstance(roi_list, list) and len(roi_list) == 4:
+                    self._template_roi[kind][name] = tuple(int(v) for v in roi_list)
+
         self._song_select_tpls = self._load_scene_templates("song_select")
         self._results_tpls = self._load_scene_templates("results")
         self._playing_tpls = self._load_scene_templates("playing")
@@ -85,7 +93,7 @@ class SceneGate:
                     "armed": True,
                     "state_transitioned": False,
                 }
-            rs_ok, rs_val = self._vote(frame_bgr, self._results_tpls, self._results_thresh)
+            rs_ok, rs_val = self._vote(frame_bgr, self._results_tpls, self._results_thresh, "results")
             if rs_ok:
                 target = STATE_RESULTS
             else:
@@ -95,9 +103,9 @@ class SceneGate:
                     "state_transitioned": False,
                 }
         else:
-            ss_ok, ss_val = self._vote(frame_bgr, self._song_select_tpls, self._song_select_thresh)
-            rs_ok, rs_val = self._vote(frame_bgr, self._results_tpls, self._results_thresh)
-            pl_ok, pl_val = self._vote(frame_bgr, self._playing_tpls, self._playing_thresh)
+            ss_ok, ss_val = self._vote(frame_bgr, self._song_select_tpls, self._song_select_thresh, "song_select")
+            rs_ok, rs_val = self._vote(frame_bgr, self._results_tpls, self._results_thresh, "results")
+            pl_ok, pl_val = self._vote(frame_bgr, self._playing_tpls, self._playing_thresh, "playing")
 
             if ss_ok:
                 target = STATE_SONG_SELECT
@@ -138,6 +146,7 @@ class SceneGate:
         frame_bgr: NDArray[np.uint8],
         templates: list[tuple[str, NDArray[np.uint8]]],
         threshold: float,
+        kind: str = "",
     ) -> tuple[bool, float]:
         if not templates:
             return False, 0.0
@@ -145,11 +154,23 @@ class SceneGate:
         vote_count = 0
         required_votes = min(self._match_vote_min, len(templates))
         fh, fw = frame_bgr.shape[:2]
+        roi_map = self._template_roi.get(kind, {})
         for name, tpl in templates:
             th, tw = tpl.shape[:2]
             if th <= 0 or tw <= 0 or th > fh or tw > fw:
                 continue
-            result = cv2.matchTemplate(frame_bgr, tpl, cv2.TM_CCOEFF_NORMED)
+            roi = roi_map.get(name)
+            search_area = frame_bgr
+            if roi is not None:
+                rx, ry, rw, rh = roi
+                rx = max(0, min(rx, fw))
+                ry = max(0, min(ry, fh))
+                rw = min(rw, fw - rx)
+                rh = min(rh, fh - ry)
+                if rw < tw or rh < th:
+                    continue
+                search_area = frame_bgr[ry:ry + rh, rx:rx + rw]
+            result = cv2.matchTemplate(search_area, tpl, cv2.TM_CCOEFF_NORMED)
             _, max_val, _, _ = cv2.minMaxLoc(result)
             if max_val > best_val:
                 best_val = float(max_val)

--- a/agent/custom/action/rhythm/utils/song_selector.py
+++ b/agent/custom/action/rhythm/utils/song_selector.py
@@ -74,6 +74,11 @@ class SongSelector:
         self._song_select_enabled = bool(sc.get("enabled", False))
         self._auto_select = bool(sc.get("auto_select", False))
         self._song_name = str(sc.get("song_name", ""))
+        song_list_roi_list = sc.get("song_list_roi", [47, 117, 550, 510])
+        if isinstance(song_list_roi_list, list) and len(song_list_roi_list) == 4:
+            self._song_list_roi = tuple(int(v) for v in song_list_roi_list)
+        else:
+            self._song_list_roi = (47, 117, 550, 510)
         self._scroll_area_x_frac = float(sc.get("scroll_area_x_frac", 0.25))
         self._scroll_area_y_frac = float(sc.get("scroll_area_y_frac", 0.50))
         self._scroll_delta = int(sc.get("scroll_delta", -3))
@@ -163,7 +168,7 @@ class SongSelector:
         if self._state == _SEL_SEARCHING:
             if self._scroll_attempts > 0 and now - self._post_scroll_time < self._scroll_settle_delay:
                 return {"state": self._state, "action": "settling", "scroll_attempts": self._scroll_attempts}
-            match = self._find_template(frame_bgr, self._template, self._match_threshold)
+            match = self._find_template(frame_bgr, self._template, self._match_threshold, self._song_list_roi)
             if match is not None:
                 self._match_loc = match
                 self._consecutive_down_fails = 0
@@ -198,8 +203,8 @@ class SongSelector:
             else:
                 self._consecutive_down_fails += 1
             if scroll_func is not None:
-                sx = int(self._scroll_area_x_frac * w)
-                sy = int(self._scroll_area_y_frac * h)
+                sx = self._song_list_roi[0] + self._song_list_roi[2] // 2
+                sy = self._song_list_roi[1] + self._song_list_roi[3] // 2
                 scroll_func(sx, sy, direction)
             self._scroll_attempts += 1
             self._last_action_time = now
@@ -212,7 +217,7 @@ class SongSelector:
         if self._state == _SEL_CLICKING_SONG:
             if now - self._last_action_time < self._click_delay:
                 return {"state": self._state, "action": "waiting"}
-            current_match = self._find_template(frame_bgr, self._template, self._click_reverify_threshold)
+            current_match = self._find_template(frame_bgr, self._template, self._click_reverify_threshold, self._song_list_roi)
             if current_match is None:
                 self._click_reverify_retries += 1
                 if self._click_reverify_retries < self._max_click_reverify_retries:
@@ -282,15 +287,28 @@ class SongSelector:
         frame_bgr: NDArray[np.uint8],
         tpl: NDArray[np.uint8],
         threshold: float,
+        roi: tuple[int, int, int, int] | None = None,
     ) -> tuple[int, int] | None:
         th, tw = tpl.shape[:2]
         fh, fw = frame_bgr.shape[:2]
         if th > fh or tw > fw:
             return None
-        result = cv2.matchTemplate(frame_bgr, tpl, cv2.TM_CCOEFF_NORMED)
+        search_area = frame_bgr
+        offset_x, offset_y = 0, 0
+        if roi is not None:
+            rx, ry, rw, rh = roi
+            rx = max(0, min(rx, fw))
+            ry = max(0, min(ry, fh))
+            rw = min(rw, fw - rx)
+            rh = min(rh, fh - ry)
+            if rw < tw or rh < th:
+                return None
+            search_area = frame_bgr[ry:ry + rh, rx:rx + rw]
+            offset_x, offset_y = rx, ry
+        result = cv2.matchTemplate(search_area, tpl, cv2.TM_CCOEFF_NORMED)
         _, max_val, _, max_loc = cv2.minMaxLoc(result)
         if max_val >= threshold:
-            cx = max_loc[0] + tw // 2
-            cy = max_loc[1] + th // 2
+            cx = max_loc[0] + tw // 2 + offset_x
+            cy = max_loc[1] + th // 2 + offset_y
             return cx, cy
         return None

--- a/assets/resource/base/pipeline/Rhythm/Rhythm.json
+++ b/assets/resource/base/pipeline/Rhythm/Rhythm.json
@@ -25,7 +25,12 @@
             "RhythmSceneOnPlaying"
         ],
         "pre_wait_freezes": {
-            "target": [0, 0, 100, 100],
+            "target": [
+                0,
+                0,
+                100,
+                100
+            ],
             "time": 500,
             "timeout": 10000
         },
@@ -35,8 +40,6 @@
     },
     "RhythmPlaying": {
         "desc": "演奏主流程 - 鼓面检测紧凑循环",
-        "anchor": "RhythmLoopPoint",
-        "max_hit": 999,
         "action": "Custom",
         "custom_action": "auto_rhythm_play",
         "custom_action_param": {},
@@ -52,7 +55,7 @@
         "next": [
             "RhythmOnResults",
             "RhythmOnSongSelect",
-            "[Anchor]RhythmLoopPoint"
+            "RhythmCheckVitality"
         ]
     },
     "RhythmOnResults": {
@@ -89,7 +92,9 @@
         "action": {
             "type": "ClickKey",
             "param": {
-                "key": [27]
+                "key": [
+                    27
+                ]
             }
         },
         "post_delay": 800,

--- a/assets/resource/tasks/Rhythm.json
+++ b/assets/resource/tasks/Rhythm.json
@@ -1,7 +1,7 @@
 {
     "task": [
         {
-            "name": "自动演奏",
+            "name": "超强音",
             "entry": "RhythmEntrance",
             "option": [
                 "自动选曲",


### PR DESCRIPTION
## 修改概览

超强音（Rhythm）模块的三个 Bug 修复和一项功能增强：

### Bug 修复

#### 1. 冷却锁过期后用 SceneGate 多模板场景识别取代单一 pause.png 检测
- **问题**：演奏结束时，8s 冷却锁过期后仅用单一 `pause.png` 模板判断是否仍在演奏，在 results/song_select 界面容易误匹配，导致重新加锁 8s，阻塞后续任务
- **修改** (`play.py`)：冷却锁过期时，先调用 `SceneGate.step()` 进行多模板场景识别。若识别为非 playing（results/song_select/other），立即退出演奏；仅在识别为 playing 时才用 `pause.png` 模板做兜底判断
- **性能优化**：`scene_gate.step()` 仅在冷却锁过期时调用，锁有效期间跳过，不挤占鼓面检测帧率

#### 2. 连打循环跳过 RhythmSelectSong 导致在 song_select 界面卡 8s
- **问题**：连打继续时通过 `[Anchor]RhythmLoopPoint` 直接跳回 `RhythmPlaying`，但此时场景已是 song_select，仍被 8s 冷却锁卡住
- **修改** (`repeat_decision.py` + `Rhythm.json`)：连打继续跳回 `RhythmSelectSong`，走完整「选歌 → 等待演奏 → 演奏」流程；移除无用的 anchor/max_hit 配置

#### 3. 演奏结束后兜底路径跳过 OCR 导致连打 Max 失效
- **问题**：`RhythmAfterPlaying` 当 templates 匹配都失败时，兜底直接走 `RhythmDismissResults` 发 ESC，跳过了消耗活力的 OCR 识别，`_vitality_cost` 始终为 None，连打 Max 判断失效
- **修改** (`Rhythm.json`)：兜底改为走 `RhythmCheckVitality` → `RhythmDismissResults`，确保无论 template 匹配结果如何，OCR 始终执行

### 功能增强

#### 4. 场景模板 ROI 限定 + 歌单列表 ROI
- **新增配置** (`config.py`)：为 song_select/playing/results 三类场景模板定义 ROI 限定区域，避免全帧误匹配
- **SceneGate** (`presence.py`)：`_vote` 方法支持按 template name 匹配 ROI，在限定区域内做 `cv2.matchTemplate`
- **SongSelector** (`song_selector.py`)：歌名匹配和滚动操作均限定在 `song_list_roi: [47, 117, 550, 510]` 区域内，提升匹配精度和性能

## 修改文件

| 文件 | 变更 |
|------|------|
| `agent/.../rhythm/feats/play.py` | +10 行：导入 SceneGate，冷却锁过期时场景识别优先 |
| `agent/.../rhythm/feats/repeat_decision.py` | 1 行：跳转目标改为 RhythmSelectSong |
| `agent/.../rhythm/utils/config.py` | +19/-1 行：新增 template_roi、song_list_roi，移除 scene_lock_timeout_sec |
| `agent/.../rhythm/utils/presence.py` | +31/-4 行：_vote 支持 ROI 限定区域 |
| `agent/.../rhythm/utils/song_selector.py` | +32/-5 行：_find_template 支持 ROI，滚动用 ROI 中心 |
| `assets/.../Rhythm/Rhythm.json` | +15/-6 行：移除 anchor/max_hit，修复流程跳转 |

##  checklist

- [x] 本地打包功能正常

## Summary by Sourcery

通过增加基于 ROI（感兴趣区域）的模板匹配并调整重复游玩流程控制，提高节奏游戏场景检测的可靠性和歌曲选择的准确性。

New Features:
- 为节奏场景模板和歌曲列表区域添加可配置的 ROI 支持，以限制匹配范围。

Bug Fixes:
- 当游玩场景锁过期时，使用基于 SceneGate 的场景检测，避免将非游玩界面误判为正在游玩。
- 将重复游玩流程重新导回歌曲选择状态，而不是直接循环回游玩场景，以防止卡在冷却锁之后无法继续。
- 确保在游玩结束后的回退逻辑中，总是先执行体力值 OCR，再关闭结果界面，使重复游玩上限的决策基于正确的体力消耗。

Enhancements:
- 将歌曲选择模板搜索和滚动操作限制在配置的歌曲列表 ROI 内，以提高匹配精度和滚动行为的稳定性。
- 扩展 SceneGate 投票机制，使其支持针对 `song_select`、`playing` 和 `results` 场景的模板级 ROI，并将其接入游玩循环的冷却处理逻辑中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve rhythm game scene detection reliability and song selection accuracy by adding ROI-based template matching and adjusting repeat flow control.

New Features:
- Add configurable ROI support for rhythm scene templates and song list region to constrain matching areas.

Bug Fixes:
- Use SceneGate-based scene detection when the playing scene lock expires to avoid misclassifying non-playing screens as active play.
- Route repeat flows back through the song selection state instead of looping directly into playing to prevent being stuck behind the cooldown lock.
- Ensure post-playing fallback always runs vitality OCR before dismissing results so repeat-max decisions are based on correct stamina cost.

Enhancements:
- Limit song selection template search and scroll operations to the configured song list ROI to improve matching precision and scrolling behavior.
- Extend SceneGate voting to respect per-template ROIs for song_select, playing, and results scenes, and wire it into the play loop cooldown handling.

</details>