### PR TITLE
feat: 启动时自动检测管理员权限并提示提权重启

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -186,10 +186,12 @@ jobs:
             mv -f install/MaaNTE.exe install/MaaNTE-app.exe
             echo "Renamed MaaNTE.exe -> MaaNTE-app.exe"
           fi
+          ls -lh install/MaaNTE-app.exe
           pip install pyinstaller
           pyinstaller --onefile --name MaaNTE --distpath install \
-            --add-data "install/MaaNTE-app.exe:." \
+            --add-data "install/MaaNTE-app.exe;." \
             tools/ci/MaaNTE_launcher.pyw
+          ls -lh install/MaaNTE.exe
           rm -f install/MaaNTE-app.exe
           echo "Compiled MaaNTE.exe launcher (single exe)"
           rm -rf build MaaNTE.spec

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -187,8 +187,11 @@ jobs:
             echo "Renamed MaaNTE.exe -> MaaNTE-app.exe"
           fi
           pip install pyinstaller
-          pyinstaller --onefile --name MaaNTE --distpath install tools/ci/MaaNTE_launcher.pyw
-          echo "Compiled MaaNTE.exe launcher"
+          pyinstaller --onefile --name MaaNTE --distpath install \
+            --add-data "install/MaaNTE-app.exe:." \
+            tools/ci/MaaNTE_launcher.pyw
+          rm -f install/MaaNTE-app.exe
+          echo "Compiled MaaNTE.exe launcher (single exe)"
           rm -rf build MaaNTE.spec
 
       - name: Copy custom icons

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -179,6 +179,20 @@ jobs:
             echo "MFA directory not found, skipping copy."
           fi
 
+      - name: Inject admin privilege launcher
+        shell: bash
+        run: |
+          if [ -f "install/MaaNTE.exe" ]; then
+            mv -f install/MaaNTE.exe install/MaaNTE-app.exe
+            echo "Renamed MaaNTE.exe -> MaaNTE-app.exe"
+          fi
+          for f in MaaNTE_launcher.pyw MaaNTE.vbs MaaNTE.bat; do
+            if [ -f "tools/ci/$f" ]; then
+              cp "tools/ci/$f" "install/$f"
+              echo "Copied $f -> install/$f"
+            fi
+          done
+
       - name: Copy custom icons
         shell: bash
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -171,30 +171,21 @@ jobs:
             mkdir -p install
             cp -rpvn MFA/. install/
             if [ -f "install/MFAAvalonia.exe" ]; then
-              mv -f install/MFAAvalonia.exe install/MaaNTE.exe
+              mv -f install/MFAAvalonia.exe install/MaaNTE-app.exe
+              echo "Renamed MFAAvalonia.exe -> MaaNTE-app.exe"
             elif [ -f "install/MFAAvalonia" ]; then
-              mv -f install/MFAAvalonia install/MaaNTE
+              mv -f install/MFAAvalonia install/MaaNTE-app
             fi
           else
             echo "MFA directory not found, skipping copy."
           fi
 
-      - name: Inject admin privilege launcher
-        shell: bash
+      - name: Build admin privilege launcher
+        shell: powershell
         run: |
-          if [ -f "install/MaaNTE.exe" ]; then
-            mv -f install/MaaNTE.exe install/MaaNTE-app.exe
-            echo "Renamed MaaNTE.exe -> MaaNTE-app.exe"
-          fi
-          ls -lh install/MaaNTE-app.exe
-          pip install pyinstaller
-          pyinstaller --onefile --name MaaNTE --distpath install \
-            --add-data "install/MaaNTE-app.exe;." \
-            tools/ci/MaaNTE_launcher.pyw
-          ls -lh install/MaaNTE.exe
-          rm -f install/MaaNTE-app.exe
-          echo "Compiled MaaNTE.exe launcher (single exe)"
-          rm -rf build MaaNTE.spec
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vcvars = Join-Path $vsPath "VC\Auxiliary\Build\vcvarsall.bat"
+          cmd /c "`"$vcvars`" amd64 && cl /W4 /O1 /Fe:install\MaaNTE.exe tools\ci\MaaNTE_launcher.c /link /SUBSYSTEM:WINDOWS /ENTRY:WinMainCRTStartup user32.lib shell32.lib advapi32.lib"
 
       - name: Copy custom icons
         shell: bash

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -186,12 +186,10 @@ jobs:
             mv -f install/MaaNTE.exe install/MaaNTE-app.exe
             echo "Renamed MaaNTE.exe -> MaaNTE-app.exe"
           fi
-          for f in MaaNTE_launcher.pyw MaaNTE.vbs MaaNTE.bat; do
-            if [ -f "tools/ci/$f" ]; then
-              cp "tools/ci/$f" "install/$f"
-              echo "Copied $f -> install/$f"
-            fi
-          done
+          pip install pyinstaller
+          pyinstaller --onefile --name MaaNTE --distpath install tools/ci/MaaNTE_launcher.pyw
+          echo "Compiled MaaNTE.exe launcher"
+          rm -rf build MaaNTE.spec
 
       - name: Copy custom icons
         shell: bash

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -167,14 +167,12 @@ jobs:
         shell: bash
         run: |
           if [ -d "MFA" ]; then
-            echo "Copying MFA files to install directory..."
-            mkdir -p install
-            cp -rpvn MFA/. install/
-            if [ -f "install/MFAAvalonia.exe" ]; then
-              mv -f install/MFAAvalonia.exe install/MaaNTE-app.exe
-              echo "Renamed MFAAvalonia.exe -> MaaNTE-app.exe"
-            elif [ -f "install/MFAAvalonia" ]; then
-              mv -f install/MFAAvalonia install/MaaNTE-app
+            echo "Copying MFA files to install/app/..."
+            mkdir -p install/app
+            cp -rpvn MFA/. install/app/
+            if [ -f "install/app/MFAAvalonia.exe" ]; then
+              mv -f install/app/MFAAvalonia.exe install/app/MaaNTE-app.exe
+              echo "Renamed MFAAvalonia.exe -> app/MaaNTE-app.exe"
             fi
           else
             echo "MFA directory not found, skipping copy."
@@ -191,15 +189,15 @@ jobs:
         shell: bash
         run: |
           # 删除 MFAA 自带的 Assets 文件夹
-          if [ -d "install/Assets" ]; then
-            rm -rf install/Assets
+          if [ -d "install/app/Assets" ]; then
+            rm -rf install/app/Assets
             echo "Removed original Assets folder"
           fi
 
-          # MFAA 版本的图标放根目录
+          # MFAA 版本的图标放 app 目录
           if [ -f "maante.ico" ]; then
-            cp maante.ico install/logo.ico
-            echo "Copied custom icon to install/logo.ico"
+            cp maante.ico install/app/logo.ico
+            echo "Copied custom icon to install/app/logo.ico"
           fi
 
       - uses: actions/upload-artifact@v4

--- a/agent/main.py
+++ b/agent/main.py
@@ -409,16 +409,36 @@ def check_and_install_dependencies():
 
 
 def _check_admin_privilege():
-    """检查是否以管理员权限运行，若否则输出警告"""
+    """检查是否以管理员权限运行，若非则弹窗提示并自动以管理员身份重新启动"""
     import ctypes
 
     if ctypes.windll.shell32.IsUserAnAdmin():
         return
 
-    logger.warning(
-        "未以管理员权限运行，部分输入功能可能无法正常使用。"
-        "请右键 MaaNTE.exe → 以管理员身份运行。"
+    MB_YESNO = 0x04
+    MB_ICONWARNING = 0x30
+    IDYES = 6
+
+    result = ctypes.windll.user32.MessageBoxW(
+        None,
+        "当前未以管理员权限运行，部分功能可能无法正常使用。\n\n是否立即以管理员身份重新启动？",
+        "MaaNTE - 权限不足",
+        MB_YESNO | MB_ICONWARNING,
     )
+
+    if result == IDYES:
+        try:
+            exe_path = sys.executable if getattr(sys, 'frozen', False) else sys.argv[0]
+            exe_path = os.path.abspath(exe_path)
+            ret = ctypes.windll.shell32.ShellExecuteW(None, "runas", exe_path, None, None, 1)
+            if ret <= 32:
+                raise OSError(f"ShellExecuteW 返回值: {ret}")
+            sys.exit(0)
+        except Exception as e:
+            logger.error(f"以管理员身份重启失败: {e}")
+            sys.exit(1)
+    else:
+        logger.warning("用户选择不以管理员权限运行，部分输入功能可能无法正常使用。")
 
 
 def _check_game_resolution():

--- a/agent/main.py
+++ b/agent/main.py
@@ -431,7 +431,7 @@ def _check_admin_privilege():
         try:
             exe_path = sys.executable if getattr(sys, 'frozen', False) else sys.argv[0]
             exe_path = os.path.abspath(exe_path)
-            params = " ".join(sys.argv[1:])
+            params = subprocess.list2cmdline(sys.argv[1:])
             ret = ctypes.windll.shell32.ShellExecuteW(
                 None, "runas", exe_path, params or None, None, SW_SHOWNORMAL,
             )
@@ -439,8 +439,7 @@ def _check_admin_privilege():
                 raise OSError(f"ShellExecuteW 返回值: {ret}")
             sys.exit(0)
         except OSError:
-            logger.exception("以管理员身份重启失败")
-            sys.exit(1)
+            logger.exception("以管理员身份重启失败，将以普通权限继续运行")
     else:
         logger.warning("用户选择不以管理员权限运行，部分输入功能可能无法正常使用。")
 

--- a/agent/main.py
+++ b/agent/main.py
@@ -412,7 +412,14 @@ def _check_admin_privilege():
     """检查是否以管理员权限运行，若非则弹窗提示并自动以管理员身份重新启动"""
     import ctypes
 
-    if ctypes.windll.shell32.IsUserAnAdmin():
+    try:
+        is_admin = ctypes.windll.shell32.IsUserAnAdmin()
+    except Exception:
+        logger.exception("IsUserAnAdmin 调用失败")
+        return
+
+    logger.info(f"管理员权限检查: is_admin={is_admin}")
+    if is_admin:
         return
 
     SW_SHOWNORMAL = 1
@@ -420,13 +427,18 @@ def _check_admin_privilege():
     MB_ICONWARNING = 0x30
     IDYES = 6
 
-    result = ctypes.windll.user32.MessageBoxW(
-        None,
-        "当前未以管理员权限运行，部分功能可能无法正常使用。\n\n是否立即以管理员身份重新启动？",
-        "MaaNTE - 权限不足",
-        MB_YESNO | MB_ICONWARNING,
-    )
+    try:
+        result = ctypes.windll.user32.MessageBoxW(
+            None,
+            "当前未以管理员权限运行，部分功能可能无法正常使用。\n\n是否立即以管理员身份重新启动？",
+            "MaaNTE - 权限不足",
+            MB_YESNO | MB_ICONWARNING,
+        )
+    except Exception:
+        logger.exception("MessageBoxW 调用失败")
+        return
 
+    logger.info(f"MessageBoxW 返回值: {result}")
     if result == IDYES:
         try:
             exe_path = sys.executable if getattr(sys, 'frozen', False) else sys.argv[0]

--- a/agent/main.py
+++ b/agent/main.py
@@ -415,6 +415,7 @@ def _check_admin_privilege():
     if ctypes.windll.shell32.IsUserAnAdmin():
         return
 
+    SW_SHOWNORMAL = 1
     MB_YESNO = 0x04
     MB_ICONWARNING = 0x30
     IDYES = 6
@@ -430,12 +431,15 @@ def _check_admin_privilege():
         try:
             exe_path = sys.executable if getattr(sys, 'frozen', False) else sys.argv[0]
             exe_path = os.path.abspath(exe_path)
-            ret = ctypes.windll.shell32.ShellExecuteW(None, "runas", exe_path, None, None, 1)
+            params = " ".join(sys.argv[1:])
+            ret = ctypes.windll.shell32.ShellExecuteW(
+                None, "runas", exe_path, params or None, None, SW_SHOWNORMAL,
+            )
             if ret <= 32:
                 raise OSError(f"ShellExecuteW 返回值: {ret}")
             sys.exit(0)
-        except Exception as e:
-            logger.error(f"以管理员身份重启失败: {e}")
+        except OSError:
+            logger.exception("以管理员身份重启失败")
             sys.exit(1)
     else:
         logger.warning("用户选择不以管理员权限运行，部分输入功能可能无法正常使用。")

--- a/build.py
+++ b/build.py
@@ -354,6 +354,18 @@ def step_copy_mfa():
         (INSTALL_DIR / "MFAAvalonia").rename(INSTALL_DIR / "MaaNTE")
         print("  重命名: MFAAvalonia -> MaaNTE")
 
+    # Windows: 注入管理员权限检查启动器
+    if platform.system() == "Windows":
+        app_path = INSTALL_DIR / "MaaNTE-app.exe"
+        if target_path.exists():
+            target_path.rename(app_path)
+            print(f"  重命名: {target_path.name} -> {app_path.name}")
+        for fname in ("MaaNTE_launcher.pyw", "MaaNTE.vbs", "MaaNTE.bat"):
+            src = TOOLS_DIR / fname
+            if src.exists():
+                shutil.copy2(src, INSTALL_DIR / fname)
+                print(f"  复制: {fname} -> install/{fname}")
+
     # 删除 MFA 自带 Assets
     assets_path = INSTALL_DIR / "Assets"
     if assets_path.exists():

--- a/tools/ci/MaaNTE.bat
+++ b/tools/ci/MaaNTE.bat
@@ -1,0 +1,1 @@
+@wscript.exe "%~dp0MaaNTE.vbs"

--- a/tools/ci/MaaNTE.vbs
+++ b/tools/ci/MaaNTE.vbs
@@ -1,0 +1,1 @@
+CreateObject("WScript.Shell").Run "python\pythonw.exe MaaNTE_launcher.pyw", 0, False

--- a/tools/ci/MaaNTE_launcher.c
+++ b/tools/ci/MaaNTE_launcher.c
@@ -10,7 +10,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     if (last_slash) *(last_slash + 1) = '\0';
 
     char app[MAX_PATH];
-    snprintf(app, MAX_PATH, "%sMaaNTE-app.exe", path);
+    char workdir[MAX_PATH];
+    snprintf(app, MAX_PATH, "%sapp\\MaaNTE-app.exe", path);
+    snprintf(workdir, MAX_PATH, "%sapp", path);
 
     if (!IsUserAnAdmin()) {
         int result = MessageBoxA(
@@ -22,7 +24,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
         if (result == IDYES) {
             HINSTANCE ret = ShellExecuteA(
-                NULL, "runas", app, NULL, NULL, SW_SHOWNORMAL
+                NULL, "runas", app, NULL, workdir, SW_SHOWNORMAL
             );
             if ((intptr_t)ret > 32) return 0;
         }
@@ -30,7 +32,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
     STARTUPINFOA si = {sizeof(si)};
     PROCESS_INFORMATION pi;
-    if (CreateProcessA(app, NULL, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) {
+    if (CreateProcessA(app, NULL, NULL, NULL, FALSE, 0, NULL, workdir, &si, &pi)) {
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
     }

--- a/tools/ci/MaaNTE_launcher.c
+++ b/tools/ci/MaaNTE_launcher.c
@@ -1,0 +1,38 @@
+#include <windows.h>
+#include <shellapi.h>
+
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+                   LPSTR lpCmdLine, int nCmdShow) {
+    char path[MAX_PATH];
+    GetModuleFileNameA(NULL, path, MAX_PATH);
+
+    char *last_slash = strrchr(path, '\\');
+    if (last_slash) *(last_slash + 1) = '\0';
+
+    char app[MAX_PATH];
+    snprintf(app, MAX_PATH, "%sMaaNTE-app.exe", path);
+
+    if (!IsUserAnAdmin()) {
+        int result = MessageBoxA(
+            NULL,
+            "当前未以管理员权限运行，部分功能可能无法正常使用。\n\n是否立即以管理员身份重新启动？",
+            "MaaNTE - 权限不足",
+            MB_YESNO | MB_ICONWARNING
+        );
+
+        if (result == IDYES) {
+            HINSTANCE ret = ShellExecuteA(
+                NULL, "runas", app, NULL, NULL, SW_SHOWNORMAL
+            );
+            if ((intptr_t)ret > 32) return 0;
+        }
+    }
+
+    STARTUPINFOA si = {sizeof(si)};
+    PROCESS_INFORMATION pi;
+    if (CreateProcessA(app, NULL, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) {
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+    }
+    return 0;
+}

--- a/tools/ci/MaaNTE_launcher.pyw
+++ b/tools/ci/MaaNTE_launcher.pyw
@@ -2,21 +2,34 @@ import ctypes
 import subprocess
 import sys
 import os
+import tempfile
+import shutil
 
 SW_SHOWNORMAL = 1
 MB_YESNO = 0x04
 MB_ICONWARNING = 0x30
 IDYES = 6
 
+BUNDLE_EXE = "MaaNTE-app.exe"
+EXTRACT_DIR = os.path.join(tempfile.gettempdir(), "MaaNTE_app")
 
-def get_app_dir():
+
+def get_bundle_dir():
     if getattr(sys, 'frozen', False):
-        return os.path.dirname(sys.executable)
+        return sys._MEIPASS
     return os.path.dirname(os.path.abspath(__file__))
 
 
+def ensure_extracted():
+    src = os.path.join(get_bundle_dir(), BUNDLE_EXE)
+    dst = os.path.join(EXTRACT_DIR, BUNDLE_EXE)
+    os.makedirs(EXTRACT_DIR, exist_ok=True)
+    shutil.copy2(src, dst)
+    return dst
+
+
 def main():
-    app = os.path.join(get_app_dir(), "MaaNTE-app.exe")
+    app = ensure_extracted()
 
     try:
         is_admin = ctypes.windll.shell32.IsUserAnAdmin()

--- a/tools/ci/MaaNTE_launcher.pyw
+++ b/tools/ci/MaaNTE_launcher.pyw
@@ -9,8 +9,14 @@ MB_ICONWARNING = 0x30
 IDYES = 6
 
 
+def get_app_dir():
+    if getattr(sys, 'frozen', False):
+        return os.path.dirname(sys.executable)
+    return os.path.dirname(os.path.abspath(__file__))
+
+
 def main():
-    app = os.path.join(os.path.dirname(os.path.abspath(__file__)), "MaaNTE-app.exe")
+    app = os.path.join(get_app_dir(), "MaaNTE-app.exe")
 
     try:
         is_admin = ctypes.windll.shell32.IsUserAnAdmin()

--- a/tools/ci/MaaNTE_launcher.pyw
+++ b/tools/ci/MaaNTE_launcher.pyw
@@ -2,34 +2,15 @@ import ctypes
 import subprocess
 import sys
 import os
-import tempfile
-import shutil
 
 SW_SHOWNORMAL = 1
 MB_YESNO = 0x04
 MB_ICONWARNING = 0x30
 IDYES = 6
 
-BUNDLE_EXE = "MaaNTE-app.exe"
-EXTRACT_DIR = os.path.join(tempfile.gettempdir(), "MaaNTE_app")
-
-
-def get_bundle_dir():
-    if getattr(sys, 'frozen', False):
-        return sys._MEIPASS
-    return os.path.dirname(os.path.abspath(__file__))
-
-
-def ensure_extracted():
-    src = os.path.join(get_bundle_dir(), BUNDLE_EXE)
-    dst = os.path.join(EXTRACT_DIR, BUNDLE_EXE)
-    os.makedirs(EXTRACT_DIR, exist_ok=True)
-    shutil.copy2(src, dst)
-    return dst
-
 
 def main():
-    app = ensure_extracted()
+    app = os.path.join(os.path.dirname(os.path.abspath(__file__)), "MaaNTE-app.exe")
 
     try:
         is_admin = ctypes.windll.shell32.IsUserAnAdmin()

--- a/tools/ci/MaaNTE_launcher.pyw
+++ b/tools/ci/MaaNTE_launcher.pyw
@@ -1,0 +1,46 @@
+import ctypes
+import subprocess
+import sys
+import os
+
+SW_SHOWNORMAL = 1
+MB_YESNO = 0x04
+MB_ICONWARNING = 0x30
+IDYES = 6
+
+
+def main():
+    app = os.path.join(os.path.dirname(os.path.abspath(__file__)), "MaaNTE-app.exe")
+
+    try:
+        is_admin = ctypes.windll.shell32.IsUserAnAdmin()
+    except Exception:
+        is_admin = True
+
+    if not is_admin:
+        try:
+            result = ctypes.windll.user32.MessageBoxW(
+                None,
+                "当前未以管理员权限运行，部分功能可能无法正常使用。\n\n是否立即以管理员身份重新启动？",
+                "MaaNTE - 权限不足",
+                MB_YESNO | MB_ICONWARNING,
+            )
+        except Exception:
+            result = 0
+
+        if result == IDYES:
+            try:
+                ret = ctypes.windll.shell32.ShellExecuteW(
+                    None, "runas", app, None, None, SW_SHOWNORMAL,
+                )
+                if ret > 32:
+                    sys.exit(0)
+            except Exception:
+                pass
+
+    subprocess.Popen([app])
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 改动内容

修改 `agent/main.py` 中的 `_check_admin_privilege()` 函数，将原来的日志警告改为：

1. 使用 Win32 `MessageBoxW` 弹出对话框，询问用户是否以管理员身份重新启动
2. 点击"是" → 调用 `ShellExecuteW` 以 `runas` 动词重新启动程序，当前进程退出
3. 点击"否" → 记录警告日志，继续正常运行（保持原有行为）

## 动机

原实现仅在日志中输出警告，用户需要手动右键 exe 以管理员身份运行，体验不佳。改为自动弹窗提示并支持一键提权重启。

## Summary by Sourcery

Enhancements:
- 将原先仅记录日志的被动式管理员权限警告，替换为交互式 Windows 对话框，该对话框提供一键提升权限并重启的选项，同时也允许用户在不提升权限的情况下继续使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace passive log-only admin privilege warning with an interactive Windows dialog that offers one-click elevation and restart while allowing users to continue without elevation if they choose.

</details>
- 将仅记录日志的被动管理员权限警告，替换为交互式 Windows 对话框，使用户可以选择以提升权限重新启动应用，或在不提升权限的情况下继续运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- 将原先仅记录日志的被动式管理员权限警告，替换为交互式 Windows 对话框，该对话框提供一键提升权限并重启的选项，同时也允许用户在不提升权限的情况下继续使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace passive log-only admin privilege warning with an interactive Windows dialog that offers one-click elevation and restart while allowing users to continue without elevation if they choose.

</details>

</details>