### PR TITLE
feat: 启动时自动检测管理员权限并提示提权

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -150,9 +150,12 @@ jobs:
       - name: Embed UAC admin manifest
         shell: powershell
         run: |
-          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $mtExe = Get-ChildItem -Path "$vsPath\..\..\Windows Kits\*\bin\*\x64\mt.exe" -ErrorAction SilentlyContinue | Sort-Object -Descending | Select-Object -First 1
-          if (-not $mtExe) { $mtExe = Get-Command mt.exe -ErrorAction Stop }
+          $mtExe = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\mt.exe" -ErrorAction SilentlyContinue | Sort-Object -Descending | Select-Object -First 1
+          if (-not $mtExe) {
+            Write-Error "mt.exe not found"
+            exit 1
+          }
+          Write-Host "Using mt.exe: $($mtExe.FullName)"
           & $mtExe.FullName -manifest tools/ci/app.manifest -outputresource:"MFA/MFAAvalonia.exe;#1"
           echo "Embedded UAC manifest into MFA/MFAAvalonia.exe"
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -147,6 +147,15 @@ jobs:
             echo "MFAAvalonia exe not found, skipping icon update."
           fi
 
+      - name: Embed UAC admin manifest
+        shell: powershell
+        run: |
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $mtExe = Get-ChildItem -Path "$vsPath\..\..\Windows Kits\*\bin\*\x64\mt.exe" -ErrorAction SilentlyContinue | Sort-Object -Descending | Select-Object -First 1
+          if (-not $mtExe) { $mtExe = Get-Command mt.exe -ErrorAction Stop }
+          & $mtExe.FullName -manifest tools/ci/app.manifest -outputresource:"MFA/MFAAvalonia.exe;#1"
+          echo "Embedded UAC manifest into MFA/MFAAvalonia.exe"
+
       - name: Setup Embed Python on Windows
         shell: bash
         run: |

--- a/tools/ci/app.manifest
+++ b/tools/ci/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
## Summary
- 通过嵌入 UAC manifest，双击 MaaNTE.exe 时 Windows 自动弹出管理员权限提示
- 无需启动器，保持单一 exe 发布结构
- 在 CI 构建流程中用 mt.exe 将 requireAdministrator manifest 嵌入 MFAAvalonia.exe

## 方案说明
给 MFAAvalonia.exe 嵌入 Windows 应用清单（manifest），声明 requestedExecutionLevel=requireAdministrator。Windows 会在用户双击 exe 时自动弹出 UAC 提示，无需额外的启动器或 wrapper。

## Test plan
- [ ] CI 构建产物中只有一个 MaaNTE.exe（无额外启动器文件）
- [ ] 双击 MaaNTE.exe 时弹出 Windows UAC 提示
- [ ] 点击"是"后应用以管理员权限启动
- [ ] 点击"否"后应用正常启动（无管理员权限）