### PR TITLE
fix/fish-new: 钓鱼优化，以及少量bug修复

### DIFF
--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -78,6 +78,12 @@
         },
         "pre_delay": 0,
         "post_wait_freezes": {
+            "target": [
+                0,
+                0,
+                0,
+                0
+            ],
             "time": 1000,
             "timeout": 6000
         },
@@ -202,10 +208,6 @@
                 ],
                 "template": "Fish/FishGeneralBait.png"
             }
-        },
-        "action": "Click",
-        "focus": {
-            "Node.Action.Succeeded": "选择万能鱼饵"
         },
         "next": [
             "[JumpBack]FishNewBaitDetail",

--- a/assets/resource/base/pipeline/Fish/FishStatus.json
+++ b/assets/resource/base/pipeline/Fish/FishStatus.json
@@ -7,7 +7,12 @@
         "recognition": {
             "type": "ColorMatch",
             "param": {
-                "roi": [395,33,500,35],
+                "roi": [
+                    399,
+                    43,
+                    486,
+                    14
+                ],
                 "method": 40,
                 "lower": [
                     78,
@@ -30,7 +35,12 @@
         "recognition": {
             "type": "ColorMatch",
             "param": {
-                "roi": [395,33,500,35],
+                "roi": [
+                    399,
+                    43,
+                    486,
+                    14
+                ],
                 "method": 40,
                 "lower": [
                     24,


### PR DESCRIPTION
1. 调整FishNewGaming中wait freeze的target，原本的识别到了钓鱼黄指针的位置，导致钓鱼结束等待时间过长
2. 暂时删去选中万能鱼饵的click，也无需处理可能出现的万能鱼饵界面
3. 减小识别cursor与greenbar的roi，减少昼夜交替或天气变化误识别的可能性
close #162 