### PR TITLE
fix(FishNew): 新钓鱼[点最大按钮点不动]和[买鱼饵]问题修复 fix(SoundDodge): 调整说明文本样式

### DIFF
--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -486,7 +486,6 @@
         "action": "Click",
         "next": [
             "FishNewConfirmBuyBait",
-            "FishNewStoreContinue",
             "FishNewSellFishEntrance"
         ]
     },

--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -378,7 +378,7 @@
         "template": [
             "Fish/FishStoreGeneralBait.png"
         ],
-        "threshold": 0.8,
+        // "threshold": 0.8, // 0.8 有点高了
         "action": "Click",
         "next": [
             "FishNewStoreChooseMaxSuccess",
@@ -430,6 +430,7 @@
                 "threshold": 0.8
             }
         },
+        "pre_delay": 500,
         "action": "Click"
     },
     "FishNewStoreChooseMaxSuccess": {
@@ -485,6 +486,7 @@
         "action": "Click",
         "next": [
             "FishNewConfirmBuyBait",
+            "FishNewStoreContinue",
             "FishNewSellFishEntrance"
         ]
     },

--- a/assets/resource/tasks/SoundDodge.json
+++ b/assets/resource/tasks/SoundDodge.json
@@ -3,7 +3,7 @@
         {
             "name": "音频闪避",
             "entry": "SoundDodgeMain",
-            "description": "基于音频识别的自动闪避与反击，需要[color:red]“桌面端-前台”[/color]控制器",
+            "description": "基于音频识别的自动闪避与反击，需要“<span style='color:red'>桌面端-前台</span>”控制器",
             "option": [
                 "SoundDodgeEnable",
                 "SoundDodgeAllAttacks",


### PR DESCRIPTION
新钓鱼[点最大按钮点不动]和[买鱼饵]问题修复☃️☃️

## Summary by Sourcery

修复 FishNew 新钓鱼流水线配置中的问题。

Bug 修复：
- 解决新钓鱼功能中 “max” 按钮无响应的问题。
- 修复在新钓鱼流程中购买鱼饵时导致问题的配置错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix issues in the new fishing pipeline configuration for FishNew.

Bug Fixes:
- Resolve the unresponsive 'max' button behavior in the new fishing feature.
- Fix configuration causing problems when purchasing fishing bait in the new fishing flow.

</details>