### PR TITLE
添加cc用的skill文档，尚不完善，可做修改

### DIFF
--- a/.claude/skills/dmp-analysis/SKILL.md
+++ b/.claude/skills/dmp-analysis/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: windows-dmp-analysis
+description: 分析 Windows 崩溃转储文件（.dmp），诊断 MaaNTE 及其依赖项（MaaFramework、MXU）的崩溃。自动从 GitHub Releases 下载对应版本 PDB 符号，使用 minidump-stackwalk 解析堆栈轨迹并定位崩溃根因。当 issue 日志包或附件中发现 .dmp 文件，或用户要求分析 DMP/崩溃转储时使用。
+---
+
+# Windows DMP Analysis
+
+## Scope
+
+- Windows minidump (.dmp) files from MaaNTE.
+- MaaNTE crashes almost always originate in **MaaFramework** (C++) or **MXU** (Rust/Tauri), not MaaNTE's Python code.
+- Only x86_64 covered below; for aarch64, substitute `x86_64` → `aarch64` in all download URLs.
+
+## Prerequisites
+
+在本仓库的 CI workflow 中会安装并确保 `minidump-stackwalk` 和 `dump_syms` 可用。如果你在本地复现或手动运行本流程，需要自行安装这些工具：
+
+```bash
+which minidump-stackwalk && which dump_syms
+```
+
+If either is missing, install via:
+
+```bash
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+cargo binstall -y --no-confirm minidump-stackwalk dump_syms
+```
+
+## Workflow
+
+### 1. Obtain DMP
+
+Download `.dmp` to `.cache/dmp-analysis/issue-<number>/`.
+
+Sources:
+
+- Direct issue attachment (image/file link ending in `.dmp`)
+- Inside `MaaNTE-logs-*.zip` log package
+
+```bash
+WORK=".cache/dmp-analysis/issue-<NUMBER>"
+mkdir -p "$WORK"
+curl -L "<dmp_url>" -o "$WORK/crash.dmp"
+```
+
+### 2. Quick unsymbolicated analysis
+
+```bash
+minidump-stackwalk "$WORK/crash.dmp" 2>/dev/null
+```
+
+This gives without any symbols: OS info, exception type, module list with versions, raw stack frames.
+
+Identify the **crashing module** from the exception address or the top stack frame.
+
+### 3. Determine dependency versions
+
+DMP module version info is frequently empty/unavailable. Prefer log and config sources:
+
+| Priority | Source | How |
+| -------- | ------ | --- |
+| 1 | MXU logs | `maa_init success, version: v5.x.x` |
+| 2 | Agent logs | `PI_CLIENT_MAAFW_VERSION` in PI environment log |
+| 3 | Config files from logs package | `interface.json`, config files |
+| 4 | Issue text | User-reported version |
+| 5 | Module list in stackwalk output | Version column (often shows `?`) |
+
+Record:
+
+- **MaaFramework version** (e.g. `5.9.2`)
+- **MXU version** (e.g. `1.21.2`)
+
+### 4. Download PDB symbols
+
+#### MaaFramework
+
+```bash
+MAA_VER="<version>"   # e.g. 5.9.2
+curl -sL "https://github.com/MaaXYZ/MaaFramework/releases/download/v${MAA_VER}/MAA-win-x86_64-v${MAA_VER}.zip" \
+  -o "$WORK/maa-fw.zip"
+unzip -joq "$WORK/maa-fw.zip" 'symbol/*.pdb' -d "$WORK/pdb/"
+```
+
+PDB files inside `symbol/`:
+
+| PDB | Corresponding Module |
+| --- | -------------------- |
+| MaaFramework.pdb | MaaFramework.dll — core pipeline runtime |
+| MaaUtils.pdb | MaaUtils.dll — utility library |
+| MaaToolkit.pdb | MaaToolkit.dll — toolkit |
+| MaaWin32ControlUnit.pdb | MaaWin32ControlUnit.dll — Win32 controller |
+| MaaAdbControlUnit.pdb | MaaAdbControlUnit.dll — ADB controller |
+| MaaAgentServer.pdb | MaaAgentServer.dll — agent server |
+| MaaAgentClient.pdb | MaaAgentClient.dll — agent client |
+| MaaPiCli.pdb | MaaPiCli.exe — CLI entry |
+
+#### MXU
+
+```bash
+MXU_VER="<version>"   # e.g. 1.21.2
+curl -sL "https://github.com/MistEO/MXU/releases/download/v${MXU_VER}/MXU-win-x86_64-v${MXU_VER}.zip" \
+  -o "$WORK/mxu.zip"
+unzip -joq "$WORK/mxu.zip" 'mxu.pdb' -d "$WORK/pdb/"
+```
+
+### 5. Convert PDB → Breakpad .sym
+
+```bash
+mkdir -p "$WORK/symbols"
+for pdb in "$WORK/pdb/"*.pdb; do
+  name=$(basename "$pdb" .pdb)
+  header=$(dump_syms "$pdb" 2>/dev/null | head -1)
+  debug_id=$(echo "$header" | awk '{print $4}')
+  dest="$WORK/symbols/${name}.pdb/${debug_id}"
+  mkdir -p "$dest"
+  dump_syms "$pdb" > "$dest/${name}.sym" 2>/dev/null
+done
+```
+
+### 6. Full symbolicated stack walk
+
+```bash
+minidump-stackwalk "$WORK/crash.dmp" "$WORK/symbols" 2>/dev/null
+```
+
+### 7. Analyze results
+
+#### What to focus on
+
+1. **Crashing thread** — read stack top-down.
+2. **Exception type**:
+    - `EXCEPTION_ACCESS_VIOLATION` (0xC0000005) — null/dangling pointer, use-after-free
+    - `EXCEPTION_STACK_OVERFLOW` (0xC00000FD) — infinite recursion or oversized stack allocation
+    - `EXCEPTION_ILLEGAL_INSTRUCTION` (0xC000001D) — corrupted code or wrong CPU feature
+    - `STATUS_STACK_BUFFER_OVERRUN` (0xC0000409) — **NOT always a real buffer overrun.** Check the first exception parameter:
+        - `0x7` = `FAST_FAIL_FATAL_APP_EXIT` — `std::terminate()` / `abort()` was called, typically from an **unhandled C++ exception** (e.g. `cv::Exception` from OpenCV). This is the most common crash pattern.
+        - `0x2` = `FAST_FAIL_RANGE_CHECK_FAILURE`
+        - Other values: see [FAST_FAIL codes](https://learn.microsoft.com/en-us/windows/win32/debug/fast-fail-constants)
+    - `EXCEPTION_BREAKPOINT` (0x80000003) — deliberate crash / assertion failure / Rust panic
+3. **Faulting module ownership**:
+    - `Maa*.dll` → MaaFramework → upstream `MaaXYZ/MaaFramework`
+    - `mxu.exe` → MXU → upstream `MistEO/MXU`
+    - `onnxruntime_maa.dll`, `opencv_world4_maa.dll` → third-party inference/vision
+    - `DirectML.dll` → DirectX ML runtime
+    - `ntdll.dll`, `KERNELBASE.dll`, `ucrtbase.dll` → OS / CRT; look at the caller frames above
+    - If crash address is in `ucrtbase.dll` with code 0xC0000409, the real crash site is in the **caller frames**, not ucrtbase itself
+
+### 8. Cross-reference with source
+
+If the crash is in MaaFramework:
+
+```bash
+git clone --depth 1 --branch "v${MAA_VER}" \
+  https://github.com/MaaXYZ/MaaFramework.git ".cache/upstream-src/MaaFramework"
+```
+
+If the crash is in MXU:
+
+```bash
+git clone --depth 1 --branch "v${MXU_VER}" \
+  https://github.com/MistEO/MXU.git ".cache/upstream-src/MXU"
+```
+
+Look up the function and line from the symbolicated stack trace in the cloned source.
+
+## Output Format
+
+```markdown
+## DMP 分析结果
+
+- DMP 文件：`<filename>`
+- 操作系统：`<OS version>`
+- 异常类型：`<EXCEPTION_*>`
+- 崩溃模块：`<module_name>` (版本 `<version>`)
+- 崩溃函数：`<symbolicated function name>`
+
+## DMP 崩溃分析
+
+### 崩溃堆栈（crashing thread）
+
+<crashing thread 的全部有效符号化堆栈帧>
+
+### 关键模块版本
+
+| Module           | Version |
+| ---------------- | ------- |
+| mxu.exe          | ...     |
+| MaaFramework.dll | ...     |
+| ...              | ...     |
+
+### 根因判断
+
+- 崩溃归属：MaaFramework / MXU / 第三方依赖 / 未知
+- 分析：...
+- 置信度：高 / 中 / 低
+
+### 建议
+
+- 对用户的建议（升级、绕过方案等）
+- 对开发者的建议（上游报告、修复方向）
+```
+
+## Cleanup
+
+After analysis is complete:
+
+```bash
+rm -rf ".cache/dmp-analysis/issue-<NUMBER>"
+```

--- a/.claude/skills/maa-logging/SKILL.md
+++ b/.claude/skills/maa-logging/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: maa-logging
+description: MaaNTE Python 日志规范。覆盖 agent/utils/logger.py 的 loguru/标准 logging 使用方式、日志级别选择、格式化与最佳实践。在编写或修改 agent/ 下的 Python 代码、添加日志输出、或审查日志质量时使用。
+---
+
+# MaaNTE Python 日志规范
+
+## 架构
+
+MaaNTE 的日志系统位于 `agent/utils/logger.py`，提供统一的 `logger` 对象：
+
+- **优先 loguru**：若已安装 `loguru`，则使用 loguru 的彩色输出与结构化日志。
+- **回退标准 logging**：若未安装 loguru，使用标准库 `logging` + `TimedRotatingFileHandler`。
+- **控制台**：根据客户端类型（MXU / MFAAvalonia / 其他）自动适配输出格式（HTML 彩色 / 短标签 / ANSI 颜色）。
+- **文件**：按天滚动，保留 2 周，压缩归档；文件日志固定带时间戳和调用位置。
+
+## 导入
+
+```python
+from utils.logger import logger
+```
+
+如果模块在 `custom/action/` 下且 `utils` 不在直接路径中，参考已有代码的相对导入方式。少数子模块（如 `SoundDodgeAction.py`）通过 `custom.action.Common.logger.get_logger(__name__)` 获取独立 logger，这是为了利用 loguru 的 `{name}` 字段；若不关心区分 logger 名，直接用 `from utils.logger import logger` 即可。
+
+## 日志级别
+
+| 级别 | 用途 | 示例 |
+|------|------|------|
+| `logger.info` | 关键步骤、状态变更、任务开始/结束 | `logger.info("演奏开始")` |
+| `logger.debug` | 识别细节、中间计算结果 | `logger.debug("未识别到 %s", name)` |
+| `logger.warning` | 可恢复异常、降级、配置缺失 | `logger.warning("鼓面模板缺失，演奏检测不可用")` |
+| `logger.error` | 不可恢复错误 | `logger.error("Error: %s", e)` |
+| `logger.success` | 操作成功确认（loguru） | `logger.success("任务完成")` |
+| `logger.trace` | 逐帧/高频细节（loguru） | `logger.trace("候选入队: ...")` |
+
+## 格式化
+
+使用 `%s` / `%d` 等 `%` 风格占位符（loguru 风格），不要手动拼接字符串：
+
+```python
+# Good
+logger.info("演奏开始 | FPS=%d | 鼓面检测=%s", target_fps, drum_available)
+logger.debug("未识别到 %s", name)
+logger.warning("候选丢弃: lane=%s target=%.3f reason=min_interval", lane, target_time)
+
+# Bad
+logger.info("演奏开始 | FPS=" + str(target_fps))
+logger.info(f"演奏开始 | FPS={target_fps}")
+```
+
+## 禁止 print
+
+**所有用户可见的输出应使用 logger，禁止 `print()`**。Pipeline 的 focus 消息用于向用户展示任务进度，Python 代码中的 print 无法正确路由到 MXU/MFA 的日志面板。
+
+```python
+# Bad
+print("=== Auto Make Coffee Action Started ===")
+print(f"=== Making Coffee {count + 1}/{make_count} ===")
+
+# Good
+logger.info("冲咖啡任务开始")
+logger.info("制作进度: %d/%d", count + 1, make_count)
+```
+
+特例：`auto_tetris.py` 中 `print()` 的报告消息（如 `[泯除方块] 任务开始 | 模式: 单人`）应迁移为 `context.run_action("_MAANTE_FOCUS_", pipeline_override=...)` 或 logger。
+
+## 敏感信息
+
+不要在日志中输出密钥、完整文件路径中包含敏感信息的用户名等。
+
+## 审查清单
+
+- [ ] 导入使用 `from utils.logger import logger`（或合理的相对导入）
+- [ ] 日志级别合理：info 用于关键节点，debug 用于识别细节
+- [ ] 使用 `%` 风格占位符，不拼接字符串、不用 f-string
+- [ ] 无 `print()` 调用（应使用 logger 或 pipeline focus）
+- [ ] 无高频大量日志（循环内使用 debug/trace）
+- [ ] 异常信息包含足够的上下文（参数值、当前步骤）

--- a/.claude/skills/maante-issue-log-analysis/SKILL.md
+++ b/.claude/skills/maante-issue-log-analysis/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: maante-issue-log-analysis
+description: 分析 MaaNTE 上游仓库公开 Issue（`https://github.com/1bananachicken/MaaNTE/issues/...` 或 `#1234`）。自动抓取 issue 正文和评论中的日志附件，下载解压后从 `maa.log`、agent 日志、`mxu-tauri.log`、`mxu-web-*.log`、`mxu-agent*.log`、`config/*`、`on_error/` 中筛选关键证据，并结合 MaaNTE、MaaFramework、MXU 的代码和文档判断根因、给出修复方案。供分析 MaaNTE issue、日志包、识别失败、任务卡死、控制器差异、Pipeline/Agent/MXU 问题时使用。
+---
+
+# MaaNTE Issue Log Analysis
+
+## Scope
+
+- 用于上游公开仓库 `https://github.com/1bananachicken/MaaNTE`。
+- 输入可以是完整 issue URL，或 `#1234` 形式的 issue 编号。
+- 只分析公开 issue 中可直接访问的附件。
+- 如果 issue 没有日志包，要先明确说明证据不足，再尽量基于 issue 文本、截图、代码和文档给出初步判断。
+
+## Workflow
+
+1. 规范化输入。
+
+    - `#1234` 视为 `https://github.com/1bananachicken/MaaNTE/issues/1234`
+    - 如果不是 `1bananachicken/MaaNTE`，停止并说明此 skill 不适用。
+
+2. 获取 issue 内容。
+
+    - 优先读取 issue 页面正文和评论。
+    - 提取这些信息：版本、控制器类型、任务名、预期行为、实际行为、复现步骤、维护者评论。
+    - 如果维护者已经给出结论，不要直接照抄；仍要用日志和代码自行验证，再把维护者结论作为补强证据。
+
+3. 提取日志附件链接。
+
+    - 关注 `MaaNTE-logs-*.zip` 或类似的日志压缩包。
+    - 如果同一个 issue 有多个日志包，先看最新一次复现；如果 issue 在对比不同版本或不同控制器，再补看前面的包。
+
+4. 下载并解压日志包。
+
+    - 用 `curl -L` 或等价方式下载到仓库内临时目录，例如 `.cache/issue-logs/issue-<number>/`。
+    - 解压后用文件工具读取，不要把整份大日志完整塞进回复。
+    - 先列一遍解压目录，不要假定结构固定。日志包可能包含：
+        - 多份 `mxu-agent-<index>-<pid>.log`
+        - 多天的 `mxu-web-YYYY-MM-DD.log`
+        - Config 目录
+        - `on_error/` 截图目录
+        - `.dmp` 崩溃转储文件
+    - 如果发现 `.dmp` 文件，记录其文件名和路径，转入步骤 5。
+
+5. **DMP 崩溃转储分析（如有 `.dmp` 文件则必须执行此步骤）。**
+
+    如果在日志包内或 issue 附件中发现了 `.dmp` 文件，**立即读取 `.claude/skills/dmp-analysis/SKILL.md` 并严格按其流程执行**。不要跳过这一步，不要只凭日志文本猜测崩溃原因。
+
+6. 建立时间线。
+
+    - 先从 issue 文本判断"用户觉得出问题的时刻"。
+    - 再把 `mxu-web-*`、`mxu-tauri.log`、agent 日志、`maa.log`、`mxu-agent*.log` 串成一条时间线。
+    - 先用 `mxu-tauri.log` 或 `maa.log` 找本次提交的 `task_id`，因为一个日志包里经常混有很多历史运行。
+    - 如果有 `on_error/` 截图，用它校验当时实际停留画面；如果没有，要检查是否是未触发 `on_error`，还是日志导出因体积限制把图片截断了。
+
+7. 回溯到代码和文档。
+
+    - 任务入口、节点名、控制器限制先看 MaaNTE 仓库。
+    - Pipeline 运行语义不确定时查 MaaFramework 文档。
+    - MXU 行为或日志分层不确定时，先查 MXU README / 文档；只有文档不足或证据已指向实现层时才看源码。
+    - 输出给用户时，如果提到任务名、任务说明、选项名、提示文案，先到 `assets/resource/locales/interface/zh_cn.json` 查中文文案，不要直接把 `task id` / `option id` 当成最终展示文本。
+
+8. 只有在满足条件时才下钻第三方仓库。
+
+    - 先用 issue、日志、MaaNTE 仓库和 MaaFramework 文档做初步归因。
+    - 如果怀疑问题在 MXU、MaaFramework 或 binding 实现层，且现有证据不足以确认，再按需查看对应上游仓库源码。
+    - 常见对应关系：
+        - `MXU`：`https://github.com/MistEO/MXU`，前端配置、Tauri 后端编排、实例/任务/agent 生命周期、`mxu-tauri.log` / `mxu-web-*`
+        - `MaaFramework`：`https://github.com/MaaXYZ/MaaFramework`，Pipeline 运行时、控制器、资源加载、任务调度、`maa.log`
+    - 本地没有时再 clone 到临时目录，例如 `.cache/upstream-src/<repo>/`。
+
+## Log Map
+
+### `maa.log`
+
+- 模块归属：`MaaFramework` 核心运行时。
+- 主要内容：资源加载、控制器连接、任务启动、节点识别、动作执行、超时、回调细节、C++ 源文件和函数名。
+- 最适合看：
+    - Pipeline 是否按预期推进
+    - `next` / `on_error` 是否命中
+    - 识别算法细节（模板分数、OCR 结果、动作成功失败）
+    - 控制器、截图、资源加载层面的异常
+
+### Agent 日志（Python 侧）
+
+- 模块归属：`agent/custom/action/` 下的 Python 自定义动作。
+- 主要内容：通过 `utils.logger` 输出的结构化日志，包含自定义动作执行细节、参数解析、识别结果。
+- 最适合看：
+    - Python 自定义逻辑是否触发
+    - 参数解析是否正确
+    - 自定义识别/动作的执行流程
+- 日志级别和格式见 [maa-logging](../maa-logging/SKILL.md)。
+
+### `mxu-tauri.log`
+
+- 模块归属：MXU 的 Tauri/Rust 后端。
+- 主要内容：实例创建、控制器连接、资源加载、任务开始/停止、agent 生命周期。
+- 最适合看：
+    - MXU 是否正确把 UI 操作转成 MaaFramework/Agent 调用
+    - 任务有没有被用户手动停止
+    - agent 是否成功启动、断开、退出
+
+### `mxu-web-YYYY-MM-DD.log`
+
+- 模块归属：MXU 的 React/TypeScript 前端。
+- 主要内容：`interface.json` 加载、配置读写、任务列表解析、控制器选择、启动参数、高层 UI 流程日志。
+- 最适合看：UI 是否加载了正确配置、用户点击后提交了什么任务和配置。
+
+### `mxu-agent*.log`
+
+- 模块归属：MXU 捕获到的 agent 子进程标准输出/标准错误。
+- 主要内容：子进程控制台输出、MaaFramework stdout 内容、面向 MXU 运行日志面板的消息。
+- 最适合看：用户在 MXU 运行日志面板里实际看到了什么。
+- 注意：它是很有用的用户视角，但不是最权威的根因日志。涉及具体运行细节时，优先以 `maa.log` 和 agent 日志为准。
+
+### `config/*`
+
+- 模块归属：MXU 配置快照。
+- 常见文件：`config/mxu-MaaNTE.json`、`config/maa_option.json`
+- 最适合看：实际启用了哪些任务和选项、配置是否与用户描述一致。
+
+### `on_error/`
+
+- 模块归属：MaaFramework 错误现场截图。
+- 最适合看：实际停留界面、是否被弹窗、加载态、遮罩、分辨率等环境因素干扰。
+- 当日志和 issue 文字描述冲突时，优先相信现场截图。
+
+## How To Filter Evidence
+
+1. 先从 issue 文本拿到锚点：版本、控制器类型、任务名/入口名、用户说的"卡住/点错/识别失败"的画面。
+
+2. 再从日志里找高价值信号：
+    - `Tasker.Task.Starting` / `Succeeded` / `Failed`
+    - `Node.Recognition.Failed` 连续重复
+    - `Node.Action.Failed`
+    - `timeout`
+    - `Warn` / `Error` / `Fatal`
+    - agent 启动失败、断连、被停止
+
+3. 先锁定"这一次复现"的任务实例，再看细节：
+    - 从 `mxu-tauri.log` 找 `post_task returned task_id`
+    - 再到 `maa.log` 用这个 `task_id` 跟完整个任务
+    - 如果 issue 文本说"失败"，但目标 `task_id` 实际 `Tasker.Task.Succeeded`，要明确写出"本日志未复现用户描述的失败"
+
+4. 对 Pipeline 问题，重点看：`maa.log`、`mxu-tauri.log`
+
+5. 对 Python 扩展问题，重点看：agent 日志、`mxu-agent*.log`
+
+6. 对 UI / 配置 / 编排问题，重点看：`mxu-web-*`、`mxu-tauri.log`、`config/*`
+
+## Common Patterns
+
+- `next` 列表中的识别连续失败直到超时：常见于当前画面不在预期分支中、模板/OCR 失配、漏了中间节点、被弹窗打断。
+- 某个"兜底返回/退出"节点连续成功但流程没有前进：常见于 Pipeline 对当前状态判断错了。
+- 用户日志与当前主线代码不一致，且主线已修复：先确认用户版本，必要时切到对应 tag 核对旧逻辑。
+- issue 文字说"卡死/误点"，但对应 `task_id` 最终 `Tasker.Task.Succeeded`：先明确"本次日志没有复现出用户描述的问题"，再分析可能性。
+
+## Correlating With Code
+
+### MaaNTE
+
+- 任务入口、选项定义：`assets/resource/tasks/*.json`
+- 资源版本信息：`assets/interface.json`
+- Pipeline 节点：`assets/resource/base/pipeline/**/*.json`
+- Python 自定义动作：`agent/custom/action/**/*.py`
+- 本地化文案：`assets/resource/locales/interface/zh_cn.json`
+
+### MaaFramework
+
+- Pipeline 协议：`https://github.com/MaaXYZ/MaaFramework/raw/refs/heads/main/docs/en_us/3.1-PipelineProtocol.md`
+- interface.json / agent / controller 语义：`https://github.com/MaaXYZ/MaaFramework/raw/refs/heads/main/docs/en_us/3.3-ProjectInterfaceV2.md`
+
+### MXU
+
+- 日志分层、GUI 角色、架构：`https://raw.githubusercontent.com/MistEO/MXU/main/README.md`
+
+## Linking Code Evidence
+
+- 统一给出对应仓库的远端 GitHub `blob` 行号链接，用尖括号包裹。
+- MaaNTE 仓库链接格式：`https://github.com/EeeMaoY/MaaNTE/blob/<commit>/<path>#L1-L2`
+- `<commit>` 必须是本次分析实际依据的代码版本。
+- 如果引用 MXU、MaaFramework 等上游仓库，也用对应远端 `blob` 链接。
+
+## Output Format
+
+最终回答用这个结构：
+
+````markdown
+## Issue 概要
+
+- issue：`#1234`
+- 版本 / 控制器：优先写 `zh_cn` 中文任务名
+- 任务 / 相关选项：优先写 `assets/resource/locales/interface/zh_cn.json` 中的中文 label/description
+- 用户现象：
+
+## 关键证据
+
+<details><summary>点击此处展开</summary>
+
+- `maa.log`：...
+- agent 日志：...
+- `mxu-tauri.log`：...
+- `mxu-web-*.log`：...
+- `mxu-agent.log` / `on_error`：...
+- 代码依据：远端 GitHub 行号链接
+
+### DMP 崩溃分析
+
+（仅当 issue 存在 .dmp 文件时输出此区域。如果没有 .dmp 文件，删除整个区域。）
+
+</details>
+
+## 根因判断
+
+- 直接结论：
+- 证据链：
+
+## 给用户的建议
+
+- 用户现在可以直接尝试的动作：
+- 是否建议升级 / 重下完整包 / 同步资源 / 重置配置：
+- 是否需要等待开发者修复：
+- 是否有临时绕过方案：
+
+## 修复方案
+
+1. 代码 / Pipeline / 配置层修复
+2. 需要补充的测试或日志
+3. 如问题本身属于不支持场景，给出如何限制入口或改进提示
+
+## 置信度
+
+- 高 / 中 / 低
+- 还缺什么证据
+````
+
+## Reminders
+
+- **DMP 堆栈必须完整输出**：如果 issue 存在 `.dmp` 文件，最终报告中必须包含 `## DMP 崩溃分析` 区域，禁止省略堆栈帧。
+- **DMP 分析必须先读 skill**：发现 `.dmp` 时必须先读取 `.claude/skills/dmp-analysis/SKILL.md` 再动手。
+- 不要只看一个日志文件下结论。
+- 不要把"维护者评论"当成唯一证据。
+- 不要把环境告警自动等同于根因。
+- 如果结论是"功能不支持"，必须给出代码级依据。
+- 如果回答里出现任务名、任务描述、选项名、提示文案，优先使用 `assets/resource/locales/interface/zh_cn.json` 的中文文案。
+- 如果回答里引用了具体代码行，直接给远端 GitHub `blob` 行号链接，用尖括号包裹。
+- 如果日志和 issue 文字描述不一致，必须显式说明"证据未复现"还是"证据已复现但用户表述不精确"。

--- a/.claude/skills/pipeline-guide/SKILL.md
+++ b/.claude/skills/pipeline-guide/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: pipeline-guide
+description: MaaNTE Pipeline JSON 编写指南。基于 MaaFramework Pipeline 协议，提供节点命名、识别算法、动作类型、流程控制、可复用节点等编码规范与模式参考。在编写、修改或审查 Pipeline JSON、设计节点流程、使用 TemplateMatch/OCR/Custom 识别或 Click/Swipe 动作时使用。
+---
+
+# MaaNTE Pipeline 编写指南
+
+## 核心原则
+
+1. **状态驱动**：遵循"识别 → 操作 → 识别"循环。每次操作必须基于识别结果，禁止假设操作后画面状态。
+2. **高命中率**：扩充 `next` 列表，覆盖当前操作后所有可能画面，力争一次截图命中。
+3. **避免硬延迟**：尽量不用 `pre_delay` / `post_delay` / `timeout`，用中间识别节点或 `pre_wait_freezes` / `post_wait_freezes` 替代；当确实不需要延迟时，要在节点上显式将 `rate_limit` / `pre_delay` / `post_delay` 设为 0（协议默认 `rate_limit=1000ms`、`pre_delay/post_delay=200ms`，省略字段会引入隐式等待）。
+4. **720p 基准**：所有坐标、ROI、图片必须基于 **1280×720**。
+
+## 目录结构
+
+```
+assets/resource/base/pipeline/
+├── Common/            # 通用可复用节点（按钮、场景跳转等）
+├── Fish/              # 钓鱼任务流水线
+├── Furniture/         # 家具收取流水线
+├── Interface/         # 场景管理器接口节点
+├── Rhythm/            # 节奏任务流水线
+├── SceneManager/      # 场景管理内部节点
+├── SoundDodge/        # 闪避反击流水线
+├── Tetris/            # 俄罗斯方块流水线
+├── MakeCoffee.json    # 冲咖啡任务
+├── ClaimRewards.json  # 领取奖励
+├── WithdrawMoney.json # 补货取钱
+└── ...
+```
+
+## 节点命名
+
+- 使用 **PascalCase**，同一任务内节点以任务名/模块名为前缀。
+- 示例：`FishNewEntrance`、`TetrisEntrance`、`MakeCoffeeStart`。
+
+## Pipeline v2 格式（推荐）
+
+MaaNTE 使用 v2 格式，recognition 和 action 放入二级字典：
+
+```jsonc
+{
+    "MyNode": {
+        "recognition": {
+            "type": "TemplateMatch",
+            "param": {
+                "template": "MyTask/button.png",
+                "roi": [100, 200, 300, 100],
+                "threshold": 0.7
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "next": ["NextNode"]
+    }
+}
+```
+
+## 常用识别算法
+
+### TemplateMatch（找图）
+
+```jsonc
+"recognition": {
+    "type": "TemplateMatch",
+    "param": {
+        "template": "path/to/image.png",  // 相对 resource/base/image 文件夹
+        "roi": [x, y, w, h],              // 720p 坐标，缩小搜索范围
+        "threshold": 0.7                   // 默认 0.7，按需调整
+    }
+}
+```
+
+- 图片必须从无损原图裁剪并缩放到 720p。
+- `green_mask: true` 可遮蔽不参与匹配的区域（用 RGB(0,255,0) 涂色）。
+
+### OCR（文字识别）
+
+```jsonc
+"recognition": {
+    "type": "OCR",
+    "param": {
+        "roi": [x, y, w, h],
+        "expected": ["完整文本"]
+    }
+}
+```
+
+- `expected` 写完整文本，不要写片段。
+
+### And / Or（组合识别）
+
+```jsonc
+// And：全部子识别都成功才算命中
+"recognition": {
+    "type": "And",
+    "param": {
+        "all_of": ["NodeA", "NodeB"],
+        "box_index": 0
+    }
+}
+
+// Or：任一子识别成功即命中
+"recognition": {
+    "type": "Or",
+    "param": {
+        "any_of": ["NodeA", "NodeB"]
+    }
+}
+```
+
+### Custom（自定义识别/动作）
+
+调用 Python Agent 注册的自定义识别器或动作：
+
+```jsonc
+// 自定义动作
+"action": {
+    "type": "Custom",
+    "param": {
+        "custom_action": "auto_make_coffee",
+        "custom_action_param": {
+            "count": 10
+        }
+    }
+}
+
+// 自定义识别
+"recognition": {
+    "type": "Custom",
+    "param": {
+        "custom_recognition": "MyRecognition",
+        "custom_recognition_param": {}
+    }
+}
+```
+
+## 常用动作类型
+
+| 动作       | 用途       | 关键字段                      |
+| ---------- | ---------- | ----------------------------- |
+| `Click`    | 点击       | `target`, `target_offset`     |
+| `Swipe`    | 滑动       | `begin`, `end`, `duration`    |
+| `ClickKey` | 按键       | `key`（虚拟键码）              |
+| `InputText`| 输入文本   | `input_text`                  |
+| `StopTask` | 停止当前任务 | 无                          |
+| `Custom`   | 自定义动作 | `custom_action`, `custom_action_param` |
+| `DoNothing`| 不执行     | 无                            |
+
+`target` 支持：`true`（当前识别结果）、节点名字符串、`[x, y]`、`[x, y, w, h]`。
+
+## 流程控制
+
+### next 列表
+
+按序识别，首个命中的节点执行其 action 后成为当前节点。`next` 为空或全部超时则任务结束。
+
+### Node Attributes（节点属性）
+
+**`[JumpBack]`**：命中后执行完该节点链，自动返回父节点继续识别 next。适用于处理弹窗、加载等中断场景。
+
+```jsonc
+"next": [
+    "BusinessNode",
+    "[JumpBack]HandlePopup",
+    "[JumpBack]WaitLoading"
+]
+```
+
+**`[Anchor]`**：动态引用锚点，运行时解析为最后设置该锚点的节点。
+
+```jsonc
+"FishNewEntrance": {
+    "anchor": "FishNewRestart"
+}
+// ...
+"next": ["[Anchor]FishNewRestart"]
+```
+
+### 等待画面稳定
+
+用 `pre_wait_freezes` / `post_wait_freezes` 等待画面静止：
+
+```jsonc
+"post_wait_freezes": {
+    "time": 200,
+    "target": [0, 0, 0, 0]  // 全屏
+}
+```
+
+### max_hit
+
+限制节点最大命中次数：
+
+```jsonc
+"max_hit": 3
+```
+
+### focus（用户提示消息）
+
+用于向用户展示任务进度或状态：
+
+```jsonc
+"focus": {
+    "Node.Action.Succeeded": "钓到鱼了！"
+}
+```
+
+或用于识别成功时通知：
+
+```jsonc
+"focus": {
+    "Node.Recognition.Succeeded": "库存已满"
+}
+```
+
+### on_error
+
+识别超时或动作失败时执行的节点列表：
+
+```jsonc
+"on_error": ["TetrisExit"]
+```
+
+## 典型模式
+
+### 带中断处理的任务入口
+
+```jsonc
+{
+    "MyTaskEntry": {
+        "next": [
+            "MyTaskMainStep",
+            "[JumpBack]HandlePopup",
+            "[JumpBack]WaitLoading"
+        ]
+    }
+}
+```
+
+### 确认后验证画面变化
+
+```jsonc
+{
+    "ClickConfirm": {
+        "recognition": { "type": "TemplateMatch", "param": { "template": "confirm.png" } },
+        "action": { "type": "Click" },
+        "post_wait_freezes": { "time": 200, "target": [0, 0, 0, 0] },
+        "next": ["VerifyNextScreen", "[JumpBack]ClickConfirm"]
+    }
+}
+```
+
+## 审查清单
+
+- [ ] 字段名拼写正确、类型合法（核对 Pipeline 协议）
+- [ ] 无不必要的 `pre_delay` / `post_delay` / `timeout`
+- [ ] `next` 列表覆盖所有可能画面，含弹窗/加载/异常
+- [ ] 每次点击后有识别验证，不假设操作后状态
+- [ ] ROI / target 坐标基于 1280×720
+- [ ] 自定义动作名与 Python `@AgentServer.custom_action("name")` 一致
+- [ ] 自定义识别/动作参数与 Python 代码中解析的参数名一致
+- [ ] OCR `expected` 写完整文本
+- [ ] 使用 `post_wait_freezes` 或中间节点避免重复点击
+
+## 参考
+
+- Pipeline 协议完整规范：[MaaFramework PipelineProtocol](https://github.com/MaaXYZ/MaaFramework/blob/main/docs/en_us/3.1-PipelineProtocol.md)
+- Python 自定义动作开发：`agent/custom/action/` 目录下的实现
+- 节点测试：`docs/zh_cn/developers/node-testing.md`

--- a/.claude/skills/pipeline-guide/field-reference.md
+++ b/.claude/skills/pipeline-guide/field-reference.md
@@ -1,0 +1,208 @@
+# Pipeline 字段速查表
+
+基于 MaaFramework Pipeline Protocol，供快速查阅字段名、类型、默认值。完整说明见 [PipelineProtocol.md](https://github.com/MaaXYZ/MaaFramework/blob/main/docs/en_us/3.1-PipelineProtocol.md)。
+
+## 通用字段
+
+| 字段                  | 类型                       | 默认值        | 说明                                     |
+| --------------------- | -------------------------- | ------------- | ---------------------------------------- |
+| `recognition`         | string \| object           | `"DirectHit"` | 识别算法（v2 用 object `{type, param}`） |
+| `action`              | string \| object           | `"DoNothing"` | 动作类型（v2 用 object `{type, param}`） |
+| `next`                | string \| NodeAttr \| list | `[]`          | 后续节点列表                             |
+| `on_error`            | string \| NodeAttr \| list | `[]`          | 超时/失败后执行的节点                    |
+| `timeout`             | int                        | `20000`       | next 循环识别超时（ms），-1 永不超时     |
+| `rate_limit`          | uint                       | `1000`        | 识别速率限制（ms）                       |
+| `pre_delay`           | uint                       | `200`         | 识别到后、执行动作前的延迟（ms）         |
+| `post_delay`          | uint                       | `200`         | 执行动作后、识别 next 前的延迟（ms）     |
+| `pre_wait_freezes`    | uint \| object             | `0`           | 动作前等待画面稳定（ms）                 |
+| `post_wait_freezes`   | uint \| object             | `0`           | 动作后等待画面稳定（ms）                 |
+| `repeat`              | uint                       | `1`           | 动作重复次数                             |
+| `repeat_delay`        | uint                       | `0`           | 重复间延迟（ms）                         |
+| `repeat_wait_freezes` | uint \| object             | `0`           | 重复间等待画面稳定（ms）                 |
+| `inverse`             | bool                       | `false`       | 反转识别结果                             |
+| `enabled`             | bool                       | `true`        | 是否启用                                 |
+| `max_hit`             | uint                       | UINT_MAX      | 最大命中次数                             |
+| `anchor`              | string \| list \| object   | `""`          | 锚点名                                   |
+| `focus`               | object                     | `null`        | 节点通知                                 |
+| `attach`              | object                     | `{}`          | 附加配置（dict merge）                   |
+
+## 节点生命周期
+
+`pre_wait_freezes` → `pre_delay` → `action` → [`repeat_wait_freezes` → `repeat_delay` → `action`] × (repeat-1) → `post_wait_freezes` → `post_delay` → 截图 → 识别 next
+
+## 识别算法字段
+
+### DirectHit
+
+| 字段         | 类型                   | 默认值              |
+| ------------ | ---------------------- | ------------------- |
+| `roi`        | array<int,4> \| string | `[0,0,0,0]`（全屏） |
+| `roi_offset` | array<int,4>           | `[0,0,0,0]`         |
+
+### TemplateMatch
+
+| 字段                 | 类型                   | 默认值                        |
+| -------------------- | ---------------------- | ----------------------------- |
+| `template`           | string \| list<string> | **必填**                      |
+| `roi` / `roi_offset` | 同 DirectHit           |                               |
+| `threshold`          | double \| list<double> | `0.7`                         |
+| `order_by`           | string                 | `"Horizontal"`                |
+| `index`              | int                    | `0`                           |
+| `method`             | int                    | `5`（TM_CCOEFF_NORMED，推荐） |
+| `green_mask`         | bool                   | `false`                       |
+
+### FeatureMatch
+
+| 字段                 | 类型                   | 默认值           |
+| -------------------- | ---------------------- | ---------------- |
+| `template`           | string \| list<string> | **必填**         |
+| `roi` / `roi_offset` | 同 DirectHit           |                  |
+| `count`              | uint                   | `4`              |
+| `detector`           | string                 | `"SIFT"`（推荐） |
+| `ratio`              | double                 | `0.6`            |
+| `order_by`           | string                 | `"Horizontal"`   |
+| `index`              | int                    | `0`              |
+| `green_mask`         | bool                   | `false`          |
+
+### ColorMatch
+
+| 字段                 | 类型                         | 默认值         |
+| -------------------- | ---------------------------- | -------------- |
+| `roi` / `roi_offset` | 同 DirectHit                 |                |
+| `method`             | int                          | `4`（RGB）     |
+| `lower`              | list<int> \| list<list<int>> | **必填**       |
+| `upper`              | list<int> \| list<list<int>> | **必填**       |
+| `count`              | uint                         | `1`            |
+| `connected`          | bool                         | `false`        |
+| `order_by`           | string                       | `"Horizontal"` |
+| `index`              | int                          | `0`            |
+
+### OCR
+
+| 字段                 | 类型                    | 默认值                    |
+| -------------------- | ----------------------- | ------------------------- |
+| `roi` / `roi_offset` | 同 DirectHit            |                           |
+| `expected`           | string \| list<string>  | 匹配全部                  |
+| `threshold`          | double                  | `0.3`                     |
+| `replace`            | array<string,2> \| list | 无                        |
+| `only_rec`           | bool                    | `false`                   |
+| `model`              | string                  | `""`（默认模型）          |
+| `color_filter`       | string                  | `""`（ColorMatch 节点名） |
+| `order_by`           | string                  | `"Horizontal"`            |
+| `index`              | int                     | `0`                       |
+
+### NeuralNetworkClassify
+
+| 字段                 | 类型             | 默认值         |
+| -------------------- | ---------------- | -------------- |
+| `roi` / `roi_offset` | 同 DirectHit     |                |
+| `model`              | string           | **必填**       |
+| `labels`             | list<string>     | `["Unknown"]`  |
+| `expected`           | int \| list<int> | 匹配全部       |
+| `order_by`           | string           | `"Horizontal"` |
+| `index`              | int              | `0`            |
+
+### NeuralNetworkDetect
+
+| 字段                 | 类型                   | 默认值         |
+| -------------------- | ---------------------- | -------------- |
+| `roi` / `roi_offset` | 同 DirectHit           |                |
+| `model`              | string                 | **必填**       |
+| `labels`             | list<string>           | 自动读取       |
+| `expected`           | int \| list<int>       | 匹配全部       |
+| `threshold`          | double \| list<double> | `0.3`          |
+| `order_by`           | string                 | `"Horizontal"` |
+| `index`              | int                    | `0`            |
+
+### And
+
+| 字段        | 类型                   | 默认值   |
+| ----------- | ---------------------- | -------- |
+| `all_of`    | list<string \| object> | **必填** |
+| `box_index` | int                    | `0`      |
+
+### Or
+
+| 字段     | 类型                   | 默认值   |
+| -------- | ---------------------- | -------- |
+| `any_of` | list<string \| object> | **必填** |
+
+### Custom
+
+| 字段                       | 类型         | 默认值   |
+| -------------------------- | ------------ | -------- |
+| `custom_recognition`       | string       | **必填** |
+| `custom_recognition_param` | any          | `null`   |
+| `roi` / `roi_offset`       | 同 DirectHit |          |
+
+## 动作字段
+
+### Click / LongPress
+
+| 字段            | 类型                                           | 默认值      |
+| --------------- | ---------------------------------------------- | ----------- |
+| `target`        | true \| string \| array<int,2> \| array<int,4> | `true`      |
+| `target_offset` | array<int,4>                                   | `[0,0,0,0]` |
+| `duration`      | uint（仅 LongPress）                           | `1000`      |
+| `contact`       | uint                                           | `0`         |
+
+### Swipe
+
+| 字段                     | 类型                         | 默认值               |
+| ------------------------ | ---------------------------- | -------------------- |
+| `begin` / `begin_offset` | 同 Click target              | `true` / `[0,0,0,0]` |
+| `end` / `end_offset`     | 同 Click target（支持 list） | `true` / `[0,0,0,0]` |
+| `duration`               | uint \| list<uint>           | `200`                |
+| `end_hold`               | uint \| list<uint>           | `0`                  |
+| `contact`                | uint                         | `0`                  |
+
+### Scroll
+
+| 字段                       | 类型     | 默认值               |
+| -------------------------- | -------- | -------------------- |
+| `target` / `target_offset` | 同 Click | `true` / `[0,0,0,0]` |
+| `dx`                       | int      | `0`                  |
+| `dy`                       | int      | `0`                  |
+
+### Custom Action
+
+| 字段                       | 类型     | 默认值               |
+| -------------------------- | -------- | -------------------- |
+| `custom_action`            | string   | **必填**             |
+| `custom_action_param`      | any      | `null`               |
+| `target` / `target_offset` | 同 Click | `true` / `[0,0,0,0]` |
+
+### 其他动作
+
+| 动作                        | 关键字段                                               |
+| --------------------------- | ------------------------------------------------------ |
+| `ClickKey` / `LongPressKey` | `key: int \| list<int>`, `duration`（仅 LongPressKey） |
+| `KeyDown` / `KeyUp`         | `key: int`                                             |
+| `InputText`                 | `input_text: string`                                   |
+| `StartApp` / `StopApp`      | `package: string`                                      |
+| `Shell`                     | `cmd: string`, `shell_timeout: int`（默认 20000）      |
+| `Command`                   | `exec: string`, `args: list<string>`, `detach: bool`   |
+| `Screencap`                 | `filename: string`, `format: string`, `quality: int`   |
+
+## order_by 排序方式
+
+| 值           | 说明             | 适用算法                                          |
+| ------------ | ---------------- | ------------------------------------------------- |
+| `Horizontal` | 左→右，同列上→下 | 全部                                              |
+| `Vertical`   | 上→下，同行左→右 | 全部                                              |
+| `Score`      | 分数降序         | TemplateMatch, FeatureMatch, NNClassify, NNDetect |
+| `Area`       | 面积降序         | FeatureMatch, ColorMatch, OCR, NNDetect           |
+| `Length`     | 文本长度降序     | OCR                                               |
+| `Random`     | 随机             | 全部                                              |
+| `Expected`   | 按 expected 顺序 | OCR, NNClassify, NNDetect                         |
+
+## wait_freezes object 字段
+
+| 字段                       | 类型     | 默认值               |
+| -------------------------- | -------- | -------------------- |
+| `time`                     | uint     | `1`                  |
+| `target` / `target_offset` | 同 Click | `true` / `[0,0,0,0]` |
+| `threshold`                | double   | `0.95`               |
+| `method`                   | int      | `5`                  |
+| `rate_limit`               | uint     | `1000`               |
+| `timeout`                  | int      | `20000`              |

--- a/.claude/skills/python-action-guide/SKILL.md
+++ b/.claude/skills/python-action-guide/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: python-action-guide
+description: MaaNTE Python 自定义动作（CustomAction）编写指南。覆盖 agent/custom/action/ 下的 Python 代码的架构、注册、命名、日志、Controller API、Pipeline 集成、错误处理等编码规范和模式参考。在编写、修改或审查 Python 自定义动作，或需要了解 agent 项目结构与 MaaFramework Python 绑定集成方式时使用。
+---
+
+# MaaNTE Python CustomAction 编写指南
+
+## 架构定位
+
+Python CustomAction 处理 Pipeline JSON 无法覆盖的复杂逻辑（图像算法、状态机、音频检测、MIDI 播放等）。禁止在 Python 中编写大规模业务流程——流程控制由 Pipeline JSON 负责。
+
+所有坐标与图像以 **720p (1280×720)** 为基准。
+
+## 目录结构
+
+```
+agent/
+├── main.py                         # 入口：venv、依赖安装、AgentServer 启动
+├── custom/
+│   ├── __init__.py                 # from .action import *
+│   └── action/
+│       ├── __init__.py             # 所有 CustomAction 的 import 与 __all__ 注册
+│       ├── Common/                 # 通用工具（click、alt_click、logger、utils）
+│       │   ├── __init__.py
+│       │   ├── click.py
+│       │   ├── alt_click.py
+│       │   ├── logger.py
+│       │   └── utils.py            # get_image、click_rect、match_template_in_region
+│       ├── AutoFish/               # 钓鱼业务（按功能聚合）
+│       ├── Tetris/                 # 俄罗斯方块业务
+│       │   ├── feats/              # 功能实现
+│       │   └── utils/              # 工具类（棋盘、场景检测）
+│       ├── rhythm/                 # 节奏任务
+│       │   ├── feats/
+│       │   └── utils/
+│       ├── SoundTrigger/           # 音频触发业务
+│       ├── Movement/               # 移动控制
+│       ├── auto_piano/             # 自动钢琴
+│       ├── auto_make_coffee.py     # 单文件简单动作
+│       ├── auto_tetris.py          # 俄罗斯方块入口
+│       ├── furniture_claim.py      # 家具收取
+│       └── realtime_task.py        # 实时任务调度
+└── utils/
+    ├── logger.py                   # 日志系统（loguru/logging）
+    ├── pienv.py                    # PI 环境变量
+    ├── time.py                     # 时间工具
+    └── win32_process.py            # Win32 窗口查找
+```
+
+## 注册机制
+
+### 装饰器注册
+
+每个 CustomAction 类使用 `@AgentServer.custom_action("name")` 注册，名称必须与 Pipeline JSON 中 `custom_action` 的值一致：
+
+```python
+from maa.agent.agent_server import AgentServer
+from maa.custom_action import CustomAction
+from maa.context import Context
+
+@AgentServer.custom_action("auto_make_coffee")
+class AutoMakeCoffee(CustomAction):
+    def run(
+        self, context: Context, argv: CustomAction.RunArg
+    ) -> CustomAction.RunResult:
+        ...
+```
+
+Pipeline JSON 中对应：
+
+```jsonc
+{
+    "action": {
+        "type": "Custom",
+        "param": {
+            "custom_action": "auto_make_coffee",
+            "custom_action_param": { "count": 10 }
+        }
+    }
+}
+```
+
+### `__init__.py` 注册
+
+所有 CustomAction 必须在 `agent/custom/action/__init__.py` 中导入并加入 `__all__`：
+
+```python
+from .auto_make_coffee import *
+from .Tetris import *
+
+__all__ = [
+    "AutoMakeCoffee",
+    "AutoTetris",
+    "TetrisResetContext",
+    "TetrisCheckVitalityAction",
+]
+```
+
+遗漏导入 = 动作不生效。
+
+## 命名
+
+- **类名**：PascalCase，语义化。如 `AutoMakeCoffee`、`TetrisGamePlayer`、`SoundDodgeAction`。
+- **注册名**：snake_case，与 Pipeline JSON 一致。如 `"auto_make_coffee"`、`"auto_tetris"`。
+- **文件名**：snake_case。单文件简单动作直接用 `.py` 文件；复杂模块用目录 + `__init__.py`。
+- **内部函数/变量**：snake_case，模块内部使用的加前导下划线 `_`。
+
+## CustomAction 模板
+
+### 简单动作
+
+```python
+import json
+from maa.agent.agent_server import AgentServer
+from maa.custom_action import CustomAction
+from maa.context import Context
+from utils.logger import logger
+
+@AgentServer.custom_action("my_action")
+class MyAction(CustomAction):
+    def run(
+        self, context: Context, argv: CustomAction.RunArg
+    ) -> CustomAction.RunResult:
+        logger.info("MyAction 开始")
+
+        params = {}
+        if argv.custom_action_param:
+            try:
+                params = json.loads(argv.custom_action_param)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        controller = context.tasker.controller
+
+        # 截图
+        controller.post_screencap().wait()
+        img = controller.cached_image
+
+        # 检查停止信号
+        if context.tasker.stopping:
+            return CustomAction.RunResult(success=False)
+
+        # 业务逻辑 ...
+
+        return CustomAction.RunResult(success=True)
+```
+
+### 带状态管理的动作
+
+对于需要跨多次调用保持状态的场景（如连打计数），使用模块级全局变量，并通过独立的 reset action 重置：
+
+```python
+_round_count = 0
+_task_config = {}
+
+@AgentServer.custom_action("my_reset")
+class MyResetContext(CustomAction):
+    def run(self, context, argv) -> CustomAction.RunResult:
+        global _round_count, _task_config
+        _round_count = 0
+        _task_config = {}
+        return CustomAction.RunResult(success=True)
+
+@AgentServer.custom_action("my_action")
+class MyAction(CustomAction):
+    def run(self, context, argv) -> CustomAction.RunResult:
+        global _round_count
+        _round_count += 1
+        ...
+```
+
+## Controller API
+
+通过 `context.tasker.controller` 访问，常用操作：
+
+```python
+controller = context.tasker.controller
+
+# 截图
+controller.post_screencap().wait()
+img = controller.cached_image  # numpy array (BGR or BGRA)
+
+# 点击（绝对坐标，720p 基准）
+controller.post_touch_down(x, y).wait()
+time.sleep(0.005)  # 短暂按下
+controller.post_touch_up().wait()
+
+# 按键（虚拟键码）
+controller.post_key_down(0x46).wait()  # F 键
+time.sleep(0.1)
+controller.post_key_up(0x46).wait()
+
+# 组合键：先 Alt 再点
+controller.post_key_down(0x12).wait()  # VK_MENU (Alt)
+# ... 执行点击 ...
+controller.post_key_up(0x12).wait()
+```
+
+常用虚拟键码：
+
+| 键 | 码 |
+|----|----|
+| Esc | 27 |
+| F | 70 |
+| E | 69 |
+| Q | 81 |
+| D | 0x44 |
+| F | 0x46 |
+| J | 0x4A |
+| K | 0x4B |
+
+## Pipeline 集成
+
+### context.run_recognition
+
+调用已定义的 Pipeline 识别节点：
+
+```python
+# 基本调用
+result = context.run_recognition("FurnitureOcrRec", image)
+
+# 带参数覆盖（动态 expected 文本、自定义 roi 等）
+result = context.run_recognition(
+    "FurnitureOcrRec",
+    image,
+    pipeline_override={
+        "FurnitureOcrRec": {
+            "recognition": {"param": {"expected": "仓鼠球"}}
+        }
+    },
+)
+if result and result.box:
+    x, y, w, h = result.box.x, result.box.y, result.box.w, result.box.h
+```
+
+### context.run_recognition_direct
+
+在 Python 中直接调用 MaaFramework 识别算法（无需 Pipeline 节点定义）：
+
+```python
+from maa.pipeline import JRecognitionType, JOCR
+
+detail = context.run_recognition_direct(
+    JRecognitionType.OCR, JOCR(roi=[x, y, w, h]), frame
+)
+if detail and detail.hit and detail.best_result:
+    text = detail.best_result.text
+```
+
+### context.run_action
+
+调用 Pipeline 中定义的动作节点：
+
+```python
+context.run_action(
+    "_MAANTE_FOCUS_",
+    pipeline_override={
+        "_MAANTE_FOCUS_": {
+            "focus": {"Node.Action.Starting": "消息内容"},
+            "action": "DoNothing",
+            "pre_delay": 0,
+            "post_delay": 0,
+        }
+    },
+)
+```
+
+### context.run_task
+
+启动子任务链：
+
+```python
+context.run_task("FurnitureClaim", pipeline_override={...})
+```
+
+### context.override_next
+
+动态修改节点的 `next` 列表，用于运行时流程控制：
+
+```python
+context.override_next("RhythmRepeatCheck", ["RhythmExit"])
+```
+
+## 错误处理
+
+- `run()` 返回 `CustomAction.RunResult(success=True/False)` 表示动作成功/失败。
+- 失败时 MaaFramework 会走 Pipeline 中该节点的 `on_error` 分支。
+- 异常应捕获并记录，避免静默吞掉：
+
+```python
+try:
+    params = json.loads(argv.custom_action_param)
+except (json.JSONDecodeError, ValueError, TypeError) as e:
+    logger.warning("参数解析失败: %r, error: %s", argv.custom_action_param, e)
+    return CustomAction.RunResult(success=False)
+```
+
+- 停止信号检查：在长循环中定期检查 `context.tasker.stopping`，及时退出：
+
+```python
+while True:
+    if context.tasker.stopping:
+        return CustomAction.RunResult(success=False)
+    # ... 循环体 ...
+```
+
+## 日志
+
+使用 `utils.logger`，禁止 `print()`。详见 [maa-logging](../maa-logging/SKILL.md)。
+
+```python
+from utils.logger import logger
+
+logger.info("任务开始 | 参数=%s", params)
+logger.debug("识别结果: %s", result)
+logger.warning("模板缺失，功能降级")
+logger.error("不可恢复错误: %s", e)
+```
+
+## 资源路径
+
+模板图片等资源文件放在 `assets/resource/base/image/` 下。在代码中引用：
+
+```python
+from pathlib import Path
+
+base = Path(__file__).parents[4] / "assets" / "resource" / "base"
+if not base.exists():
+    base = Path(__file__).parents[4] / "resource" / "base"
+
+image_dir = base / "sounds" / "dodge.wav"
+```
+
+开发模式下（`interface.json` 版本为 `DEBUG`），cwd 切换到 `assets/`，使用 `resource/base/` 路径。
+
+## 坐标系统
+
+- 所有坐标以 **1280×720** 为基准。
+- `controller.post_screencap()` 返回的图片可能不是 720p（取决于实际窗口分辨率），但坐标逻辑仍按 720p 编写。
+- Pipeline 中 `roi`、`target` 等同样基于 720p。
+
+## 审查清单
+
+- [ ] 注册名与 Pipeline `custom_action` 值一致
+- [ ] 已在 `agent/custom/action/__init__.py` 中导入并加入 `__all__`
+- [ ] 使用 `utils.logger`，无 `print()` 调用
+- [ ] 日志使用 `%` 风格占位符，不拼接字符串
+- [ ] 无大规模流程代码——流程由 Pipeline 驱动
+- [ ] 坐标/图像基于 720p
+- [ ] 长循环中有 `context.tasker.stopping` 检查
+- [ ] 异常有合理的错误处理和返回值
+- [ ] 模块级状态变量有对应的 reset action 或清理逻辑
+- [ ] 重复逻辑已考虑抽取为 `Common/utils.py` 中的共用函数
+
+## 参考
+
+- Pipeline 协议规范：[MaaFramework PipelineProtocol](https://github.com/MaaXYZ/MaaFramework/blob/main/docs/en_us/3.1-PipelineProtocol.md)
+- 日志规范：[maa-logging skill](../maa-logging/SKILL.md)
+- Pipeline 编写：[pipeline-guide skill](../pipeline-guide/SKILL.md)
+- 项目注册示例：`agent/custom/action/__init__.py`
+- Python binding：`maa.custom_action`、`maa.context` 的 MaaFramework Python 绑定

--- a/.gitignore
+++ b/.gitignore
@@ -458,7 +458,6 @@ debug
 assets/resource/base/model/detect/limbo_stage_lightest.onnx
 assets/resource/base/model/detect/sos_nodes.onnx
 
-.claude/
 .nicegui/
 
 # local gui test


### PR DESCRIPTION
## Sourcery 总结

为 MaaNTE Python CustomAction 开发、Pipeline JSON 编写、MaaNTE 问题日志分析、Windows DMP 崩溃转储分析以及 Python 日志记录规范添加内部技能文档，包括一份 Pipeline 字段参考速查表。

文档内容：
- 引入一份针对 MaaNTE Python CustomAction 编写的综合指南，涵盖架构、注册、命名、控制器 API、Pipeline 集成、错误处理、日志记录、资源以及评审检查清单。
- 添加一份详细的 MaaNTE Pipeline JSON 编写指南，以及单独的字段参考速查表，汇总 Pipeline 协议字段、默认值和使用模式。
- 记录用于分析 MaaNTE GitHub 问题及其附带日志的工作流程，包括日志角色、证据收集以及面向根因分析的结构化输出。
- 提供一项 Windows DMP 崩溃转储分析技能，描述如何使用 MaaFramework/MXU 符号对与 MaaNTE 相关的 minidump 进行符号化并解读崩溃调用栈。
- 定义 MaaNTE Python 日志记录最佳实践，参考共享日志工具、日志级别、格式规则以及评审检查清单。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add internal skill documentation for MaaNTE Python CustomAction development, Pipeline JSON authoring, MaaNTE issue log analysis, Windows DMP crash dump analysis, and Python logging conventions, including a pipeline field reference cheat sheet.

Documentation:
- Introduce a comprehensive guide for writing MaaNTE Python CustomActions, covering architecture, registration, naming, controller APIs, pipeline integration, error handling, logging, resources, and review checklist.
- Add a detailed MaaNTE Pipeline JSON authoring guide and a separate field reference cheat sheet summarizing Pipeline protocol fields, defaults, and usage patterns.
- Document a workflow for analyzing MaaNTE GitHub issues and attached logs, including log roles, evidence collection, and structured output for root cause analysis.
- Provide a Windows DMP crash dump analysis skill describing how to symbolicate MaaNTE-related minidumps with MaaFramework/MXU symbols and interpret crash stacks.
- Define MaaNTE Python logging best practices referencing the shared logger utility, levels, formatting rules, and review checklist.

</details>