### PR TITLE
fix(FishNew): 降低滑块模板匹配阈值并添加 max_hit 防止无限循环

### DIFF
--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -499,13 +499,14 @@
                 ]
             }
         },
+        "max_hit": 5,
         "action": "LongPress",
         "pre_delay": 500 // pre或post都行
         // "post_delay": 200, // 实测必须加上这个，也不知道为什么有些电脑上快速点击没用
         // "action": "Click"
     },
     "FishNewStoreChooseMaxSuccess": {
-        "desc": "确认选中最大或鱼鳞币不足",
+        "desc": "确认选中最大或鱼鳞币不足（降低滑块阈值以提高兼容性，见 #191）",
         "recognition": "And",
         "all_of": [
             {
@@ -518,7 +519,8 @@
                 ],
                 "template": [
                     "Fish/FishStoreSlider.png"
-                ]
+                ],
+                "threshold": 0.2
             },
             {
                 "recognition": "OCR",


### PR DESCRIPTION
Closes #191

## Summary

修复 "钓鱼购买鱼饵点击最大值失败"

`FishNewStoreChooseMaxSuccess` AND 识别中 `FishStoreSlider.png` 滑块模板匹配分数仅 **0.28**（默认阈值 0.7），导致确认"已点击最大值"永远失败 → Pipeline 反复 LongPress 最大值按钮 → JumpBack 重试 → 无限循环。

## 变更

- **`FishNewStoreChooseMaxSuccess`**: 滑块 TemplateMatch 显式 `threshold: 0.2`（原默认 0.7），覆盖低分设备（实测 0.28）
- **`FishNewStoreChooseMax`**: 新增 `max_hit: 5`，防止任何原因导致的无限 JumpBack 循环

## 日志依据

maa.log (task_id=200000767):
```
12833: TemplateMatch FishStoreSlider.png → score:0.284549 → AND failed
12844: TemplateMatch FishStoreMax.png     → score:1.0      → JumpBack
12857: LongPress [1216,628]              → Action.Succeeded
[重复 5 次，node_id=300001585~300001589]
```

## Test plan

- [ ] 在低配设备（滑块模板得分 < 0.7）上验证钓鱼任务（新）能正常推进到购买确认页面
- [ ] 在正常设备上验证滑块阈值降低不会导致误匹配（ROI 很小，误匹配风险低）
- [ ] 验证 `max_hit: 5` 在异常场景下能正常终止循环

🤖 Generated with [Claude Code](https://claude.com/claude-code)