### PR TITLE
fix(SoundDodge): ole32.dll 加载失败导致 agent 启动崩溃

### DIFF
--- a/agent/custom/action/SoundTrigger/SoundDodgeAction.py
+++ b/agent/custom/action/SoundTrigger/SoundDodgeAction.py
@@ -8,8 +8,6 @@ from maa.custom_action import CustomAction
 from maa.context import Context
 
 from custom.action.Common.logger import get_logger
-from custom.action.SoundTrigger.DodgeCounterTrigger import Dodger
-from custom.action.SoundTrigger.SoundListener import Ear
 from utils.maafocus import PrintT
 
 logger = get_logger(__name__)
@@ -28,6 +26,9 @@ class Ctx:
     def setup(self, controller, threshold=0.13, counter_threshold=0.12):
         if self.active:
             return
+
+        from custom.action.SoundTrigger.DodgeCounterTrigger import Dodger
+        from custom.action.SoundTrigger.SoundListener import Ear
 
         base = Path(__file__).parents[4] / "assets" / "resource" / "base"
         if not base.exists():

--- a/agent/custom/action/SoundTrigger/SoundListener.py
+++ b/agent/custom/action/SoundTrigger/SoundListener.py
@@ -5,11 +5,13 @@ import warnings
 from typing import Callable, Optional
 
 import ctypes
+import sys
 
 import librosa
 import numpy as np
 
-ctypes.cdll.ole32  # 预加载 ole32.dll，防止嵌入式 Python 中 soundcard 的 cffi.dlopen 失败（见 #199）
+if sys.platform == "win32":
+    ctypes.cdll.ole32  # 预加载 ole32.dll，防止嵌入式 Python 中 soundcard 的 cffi.dlopen 失败（见 #199）
 import soundcard as sc
 
 warnings.filterwarnings("ignore", message="data discontinuity in recording")

--- a/agent/custom/action/SoundTrigger/SoundListener.py
+++ b/agent/custom/action/SoundTrigger/SoundListener.py
@@ -4,8 +4,12 @@ import time
 import warnings
 from typing import Callable, Optional
 
+import ctypes
+
 import librosa
 import numpy as np
+
+ctypes.cdll.ole32  # 预加载 ole32.dll，防止嵌入式 Python 中 soundcard 的 cffi.dlopen 失败（见 #199）
 import soundcard as sc
 
 warnings.filterwarnings("ignore", message="data discontinuity in recording")

--- a/agent/custom/action/SoundTrigger/__init__.py
+++ b/agent/custom/action/SoundTrigger/__init__.py
@@ -1,4 +1,13 @@
-from .SoundListener import Ear
-from .DodgeCounterTrigger import Dodger
-
 __all__ = ["Ear", "Dodger"]
+
+
+def __getattr__(name: str):
+    if name == "Ear":
+        from .SoundListener import Ear
+
+        return Ear
+    if name == "Dodger":
+        from .DodgeCounterTrigger import Dodger
+
+        return Dodger
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/agent/main.py
+++ b/agent/main.py
@@ -585,8 +585,8 @@ def agent(is_dev_mode=False):
 
         try:
             import custom
-        except Exception as e:
-            logger.error("Failed to import custom actions: %s", e, exc_info=True)
+        except ImportError:
+            logger.exception("Failed to import custom actions")
             raise
 
         Tasker.set_log_dir("./debug")

--- a/agent/main.py
+++ b/agent/main.py
@@ -585,7 +585,7 @@ def agent(is_dev_mode=False):
 
         try:
             import custom
-        except ImportError:
+        except Exception:
             logger.exception("Failed to import custom actions")
             raise
 

--- a/agent/main.py
+++ b/agent/main.py
@@ -583,7 +583,11 @@ def agent(is_dev_mode=False):
         from maa.agent.agent_server import AgentServer
         from maa.tasker import Tasker
 
-        import custom
+        try:
+            import custom
+        except Exception as e:
+            logger.error("Failed to import custom actions: %s", e, exc_info=True)
+            raise
 
         Tasker.set_log_dir("./debug")
 


### PR DESCRIPTION
Closes #199

## Summary

嵌入式 Python 环境中 `soundcard` 库通过 `cffi.dlopen('ole32')` 无法定位系统 DLL，导致 `import custom` 阶段 agent 直接崩溃。SoundDodge 的 Python 代码从未被执行，且**所有依赖 agent 的任务均受影响**（`@AgentServer.custom_action` 装饰器没机会注册）。

## 根因链

```
import custom → SoundDodgeAction → SoundListener → soundcard
  → cffi.dlopen('ole32')
  → OSError: ctypes.util.find_library() did not manage to locate a library called 'ole32'
```

`ole32.dll` 是 Windows 系统 DLL 本身存在，但嵌入式 Python 发行版中 `ctypes.util.find_library()` 的搜索路径不完整。

## 变更

| 文件 | 变更 | 作用 |
|---|---|---|
| `SoundListener.py` | `import soundcard` 前加 `ctypes.cdll.ole32` 预加载 | **根因修复** |
| `SoundDodgeAction.py` | `Ear`/`Dodger` 从模块顶层移到 `setup()` 内延迟导入 | **爆炸半径缩小**，其他任务不连带崩溃 |
| `main.py` | `import custom` 加 `try/except` + `logger.error(exc_info=True)` | **可观测性**，崩溃时有日志落盘 |

## Test plan

- [ ] 在 MaaNTE 嵌入式 Python 环境中执行 `./python/python.exe -c "import soundcard"` 确认不再报 ole32 错误
- [ ] 启动 SoundDodge 任务确认 Ear 正常初始化并监听音频
- [ ] 启动其他非 SoundDodge 任务（如钓鱼、做咖啡）确认不受影响
- [ ] 故意制造 import 错误验证 `main.py` 的 try/except 能输出日志

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 由 Sourcery 提供的摘要

改进 SoundDodge 自定义动作初始化的健壮性，防止由于与声音相关的导入失败而导致的嵌入式代理崩溃。

错误修复：
- 在导入自定义动作模块时增加防护，并进行结构化错误日志记录且重新抛出异常，使导入失败能清晰暴露，而不是导致静默崩溃。
- 将 SoundDodge 的音频处理组件创建推迟到设置阶段执行，这样与声音无关的任务就不会受到声音库导入问题的影响。
- 确保在加载声音库之前先加载 Windows 的声音依赖项，以避免在嵌入式 Python 环境中出现 ole32 DLL 解析失败的问题。

增强内容：
- 通过在导入期间记录完整异常信息，提升对自定义动作相关启动问题的可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

提升 SoundDodge 自定义动作的健壮性，使与音频相关的导入失败不再导致嵌入式代理在启动时崩溃。

Bug Fixes（错误修复）:
- 通过在导入声音库之前预加载 Windows 的 ole32 库，防止由于声卡无法找到 ole32 而导致的嵌入式代理崩溃。
- 将 SoundDodge 音频组件的创建延后到设置阶段进行，这样与音频无关的任务不会受到声音库导入问题的影响。
- 在导入自定义动作失败时，记录完整异常并重新抛出，从而对错误进行暴露，而不是在没有诊断信息的情况下崩溃。

Enhancements（增强）:
- 在 SoundTrigger 包中使用惰性属性加载机制，避免在实际访问 Ear 或 Dodger 之前导入体积庞大的音频依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness of SoundDodge custom actions so audio-related import failures no longer crash the embedded agent at startup.

Bug Fixes:
- Prevent embedded agent crashes caused by soundcard failing to locate ole32 by preloading the Windows ole32 library before importing the sound library.
- Delay creation of SoundDodge audio components until setup time so tasks unrelated to audio are not affected by sound library import issues.
- Surface failures when importing custom actions by logging the full exception and re-raising instead of crashing without diagnostics.

Enhancements:
- Use lazy attribute loading in the SoundTrigger package to avoid importing heavy audio dependencies until Ear or Dodger are actually accessed.

</details>

</details>

错误修复：
- 在导入自定义动作时增加错误日志记录，使导入失败能出现在日志中，而不是导致静默崩溃。
- 将 `SoundDodge` 相关依赖的初始化延后到设置阶段执行，这样与声音无关的任务不会受到声音相关导入问题的影响。
- 在导入声音库之前预加载 Windows 的 `ole32` 库，以避免在嵌入式 Python 环境中出现 DLL 解析错误。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

改进 SoundDodge 自定义动作初始化的健壮性，防止由于与声音相关的导入失败而导致的嵌入式代理崩溃。

错误修复：
- 在导入自定义动作模块时增加防护，并进行结构化错误日志记录且重新抛出异常，使导入失败能清晰暴露，而不是导致静默崩溃。
- 将 SoundDodge 的音频处理组件创建推迟到设置阶段执行，这样与声音无关的任务就不会受到声音库导入问题的影响。
- 确保在加载声音库之前先加载 Windows 的声音依赖项，以避免在嵌入式 Python 环境中出现 ole32 DLL 解析失败的问题。

增强内容：
- 通过在导入期间记录完整异常信息，提升对自定义动作相关启动问题的可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

提升 SoundDodge 自定义动作的健壮性，使与音频相关的导入失败不再导致嵌入式代理在启动时崩溃。

Bug Fixes（错误修复）:
- 通过在导入声音库之前预加载 Windows 的 ole32 库，防止由于声卡无法找到 ole32 而导致的嵌入式代理崩溃。
- 将 SoundDodge 音频组件的创建延后到设置阶段进行，这样与音频无关的任务不会受到声音库导入问题的影响。
- 在导入自定义动作失败时，记录完整异常并重新抛出，从而对错误进行暴露，而不是在没有诊断信息的情况下崩溃。

Enhancements（增强）:
- 在 SoundTrigger 包中使用惰性属性加载机制，避免在实际访问 Ear 或 Dodger 之前导入体积庞大的音频依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness of SoundDodge custom actions so audio-related import failures no longer crash the embedded agent at startup.

Bug Fixes:
- Prevent embedded agent crashes caused by soundcard failing to locate ole32 by preloading the Windows ole32 library before importing the sound library.
- Delay creation of SoundDodge audio components until setup time so tasks unrelated to audio are not affected by sound library import issues.
- Surface failures when importing custom actions by logging the full exception and re-raising instead of crashing without diagnostics.

Enhancements:
- Use lazy attribute loading in the SoundTrigger package to avoid importing heavy audio dependencies until Ear or Dodger are actually accessed.

</details>

</details>

</details>