### PR TITLE
fix(SoundDodge): PEP 562 延迟加载 + CI 预装 patched soundcard

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -177,10 +177,13 @@ jobs:
 
           echo "Patching soundcard ole32 → ole32.dll..."
           ./install-mxu/python/python.exe -c "
-import soundcard
+import sys, soundcard
 from pathlib import Path
 p = Path(soundcard.__path__[0]) / 'mediafoundation.py'
 c = p.read_text()
+if \"_ffi.dlopen('ole32')\" not in c:
+    print(f'ERROR: expected ole32 patch target not found in {p}. soundcard may have changed.')
+    sys.exit(1)
 c = c.replace(\"_ffi.dlopen('ole32')\", \"_ffi.dlopen('ole32.dll')\")
 p.write_text(c)
 print('Patched:', p)

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -166,6 +166,29 @@ jobs:
             cp -rpvn install/deps/. install-mxu/deps/
           fi
       
+      - name: Install and patch soundcard
+        shell: bash
+        run: |
+          echo "Installing soundcard into embedded Python..."
+          ./install-mxu/python/python.exe -m pip install \
+            --no-index \
+            --find-links install-mxu/deps \
+            soundcard
+
+          echo "Patching soundcard ole32 → ole32.dll..."
+          ./install-mxu/python/python.exe -c "
+import soundcard
+from pathlib import Path
+p = Path(soundcard.__path__[0]) / 'mediafoundation.py'
+c = p.read_text()
+c = c.replace(\"_ffi.dlopen('ole32')\", \"_ffi.dlopen('ole32.dll')\")
+p.write_text(c)
+print('Patched:', p)
+"
+
+          echo "Removing soundcard wheel from deps to prevent re-install..."
+          rm -f install-mxu/deps/soundcard-*.whl
+
       - name: Copy MXU files to MXU version
         shell: bash
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -176,18 +176,18 @@ jobs:
             soundcard
 
           echo "Patching soundcard ole32 → ole32.dll..."
-          ./install-mxu/python/python.exe -c "
-import sys, soundcard
-from pathlib import Path
-p = Path(soundcard.__path__[0]) / 'mediafoundation.py'
-c = p.read_text()
-if \"_ffi.dlopen('ole32')\" not in c:
-    print(f'ERROR: expected ole32 patch target not found in {p}. soundcard may have changed.')
-    sys.exit(1)
-c = c.replace(\"_ffi.dlopen('ole32')\", \"_ffi.dlopen('ole32.dll')\")
-p.write_text(c)
-print('Patched:', p)
-"
+          ./install-mxu/python/python.exe - << 'PYEOF'
+          import sys, soundcard
+          from pathlib import Path
+          p = Path(soundcard.__path__[0]) / 'mediafoundation.py'
+          c = p.read_text()
+          if "_ffi.dlopen('ole32')" not in c:
+              print(f'ERROR: expected ole32 patch target not found in {p}. soundcard may have changed.')
+              sys.exit(1)
+          c = c.replace("_ffi.dlopen('ole32')", "_ffi.dlopen('ole32.dll')")
+          p.write_text(c)
+          print('Patched:', p)
+          PYEOF
 
           echo "Removing soundcard wheel from deps to prevent re-install..."
           rm -f install-mxu/deps/soundcard-*.whl

--- a/agent/custom/action/SoundTrigger/__init__.py
+++ b/agent/custom/action/SoundTrigger/__init__.py
@@ -1,4 +1,13 @@
-from .SoundListener import Ear
-from .DodgeCounterTrigger import Dodger
-
 __all__ = ["Ear", "Dodger"]
+
+
+def __getattr__(name: str):
+    if name == "Ear":
+        from .SoundListener import Ear
+
+        return Ear
+    if name == "Dodger":
+        from .DodgeCounterTrigger import Dodger
+
+        return Dodger
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/agent/custom/action/SoundTrigger/__init__.py
+++ b/agent/custom/action/SoundTrigger/__init__.py
@@ -4,10 +4,8 @@ __all__ = ["Ear", "Dodger"]
 def __getattr__(name: str):
     if name == "Ear":
         from .SoundListener import Ear
-
         return Ear
     if name == "Dodger":
         from .DodgeCounterTrigger import Dodger
-
         return Dodger
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- `SoundTrigger/__init__.py`: 将 `Ear`/`Dodger` 的导入改为 PEP 562 `__getattr__` 延迟加载，避免 `import custom` 时 module-level `import soundcard` 触发 `cffi.dlopen('ole32')` 导致 agent 启动崩溃
- `install.yml`: CI 打包时将 soundcard 预装进 embedded Python 并 patch `mediafoundation.py` 中 `_ffi.dlopen('ole32')` → `_ffi.dlopen('ole32.dll')`，从源头修复 embedded Python 下 `find_library` 找不到 ole32 的问题

## Root cause
Embedded Python 环境中 `ctypes.util.find_library('ole32')` 返回 `None`，soundcard 的 cffi 调用 `dlopen('ole32')` 时因找不到库而抛出 OSError，导致整个 agent 崩溃。

## Fix
1. **延迟导入** — 只在 `Ear`/`Dodger` 被实际访问时才加载 soundcard（启用"闪避辅助"相关任务时）
2. **CI 预装 patch** — 在 CI 打包阶段直接安装 soundcard 并修 `ole32` → `ole32.dll`，用户端无需额外处理

## Test plan
- [ ] CI 构建通过：soundcard 安装 + patch 步骤成功执行
- [ ] 安装后的包启动时不再因 ole32 崩溃
- [ ] 启用闪避辅助任务时 Ear/Dodger 正常加载

## Summary by Sourcery

延迟加载声音触发组件，以避免在声卡不可用时发生崩溃，并在 CI 打包过程中确保在嵌入式 Python 中预先安装并修补声卡相关组件。

Bug 修复：
- 防止在嵌入式 Python 环境中，因声卡在加载 `ole32` 时失败而导致的代理启动崩溃。

增强：
- 为 Ear 和 Dodger 引入基于 PEP 562 的惰性加载机制，使声卡仅在这些组件首次被访问时才导入。

CI：
- 在 CI 构建过程中，将 soundcard 安装到嵌入式 Python 中，对其 mediafoundation 后端进行补丁以使用 `ole32.dll`，并在之后移除该 wheel 以避免重复安装。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Delay-load sound trigger components to avoid crashing when soundcard is unavailable and ensure soundcard is preinstalled and patched in the embedded Python during CI packaging.

Bug Fixes:
- Prevent agent startup crashes caused by soundcard failing to load ole32 in embedded Python environments.

Enhancements:
- Introduce PEP 562-based lazy loading for Ear and Dodger so soundcard is only imported when these components are first accessed.

CI:
- Install soundcard into the embedded Python during CI builds, patching its mediafoundation backend to use ole32.dll and removing the wheel afterward to avoid duplicate installation.

</details>