### PR TITLE
20260528 黑暗赛车挂机，结束还没测能不能行

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -125,7 +125,10 @@
         "resource/tasks/preset/AFK.json",
         // "resource/tasks/preset/FullDaily.json",
         // "resource/tasks/preset/QuickDaily.json",
-        "resource/tasks/preset/RealtimeAssistance.json"
+        "resource/tasks/preset/RealtimeAssistance.json",
+
+
+        "resource/tasks/DeepDarkFantasy.json"
     ],
     "option": {}
 }

--- a/assets/resource/base/pipeline/DeepDarkFantasy.json
+++ b/assets/resource/base/pipeline/DeepDarkFantasy.json
@@ -3,12 +3,12 @@
         "$__mpe_code": {
             "prefix": "",
             "coordinateMode": "absolute-v1",
-            "lastSyncTime": 1779979519020,
+            "lastSyncTime": 1779979524577,
             "isModifiedExternally": false,
             "filePath": "E:\\PyCharm\\Project\\GitMALostWord\\ddf\\assets\\resource\\base\\pipeline\\DeepDarkFantasy.json",
             "savedViewport": {
-                "x": -892,
-                "y": 66,
+                "x": -1102,
+                "y": -79,
                 "zoom": 0.75
             },
             "filename": "DeepDarkFantasy",
@@ -204,10 +204,10 @@
             "type": "OCR",
             "param": {
                 "roi": [
-                    519,
-                    453,
-                    260,
-                    184
+                    547,
+                    460,
+                    181,
+                    165
                 ],
                 "expected": [
                     "黑铁螺钉"
@@ -219,7 +219,8 @@
         },
         "timeout": 60000,
         "next": [
-            "DDF_GetIn"
+            "DDF_GetIn",
+            "[JumpBack]DDF_Wait_1_1_副本1"
         ],
         "$__mpe_code": {
             "position": {
@@ -255,6 +256,31 @@
             "position": {
                 "x": 1594,
                 "y": 167
+            }
+        }
+    },
+    "DDF_Wait_1_1_副本1": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    984,
+                    646,
+                    217,
+                    56
+                ],
+                "expected": [
+                    "离开"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "$__mpe_code": {
+            "position": {
+                "x": 2656,
+                "y": 663
             }
         }
     }

--- a/assets/resource/base/pipeline/DeepDarkFantasy.json
+++ b/assets/resource/base/pipeline/DeepDarkFantasy.json
@@ -1,0 +1,261 @@
+{
+    "$__mpe_config_DeepDarkFantasy": {
+        "$__mpe_code": {
+            "prefix": "",
+            "coordinateMode": "absolute-v1",
+            "lastSyncTime": 1779979519020,
+            "isModifiedExternally": false,
+            "filePath": "E:\\PyCharm\\Project\\GitMALostWord\\ddf\\assets\\resource\\base\\pipeline\\DeepDarkFantasy.json",
+            "savedViewport": {
+                "x": -892,
+                "y": 66,
+                "zoom": 0.75
+            },
+            "filename": "DeepDarkFantasy",
+            "version": "v1.5.3"
+        }
+    },
+    "DDF_Action": {
+        "focus": "开始黑暗赛车界",
+        "next": [
+            "DDF_GetIn"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": -89,
+                "y": 255
+            }
+        }
+    },
+    "DDF_Finish": {
+        "focus": "完成",
+        "$__mpe_code": {
+            "position": {
+                "x": 2375,
+                "y": 311
+            }
+        }
+    },
+    "DDF_GetIn": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    13,
+                    657,
+                    79,
+                    40
+                ],
+                "expected": [
+                    "Enter"
+                ]
+            }
+        },
+        "next": [
+            "DDF_GetIn_1_1"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 332,
+                "y": 259
+            }
+        }
+    },
+    "DDF_GetIn_1_1": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    13,
+                    657,
+                    79,
+                    40
+                ],
+                "expected": [
+                    "Enter"
+                ]
+            }
+        },
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": [
+                    115
+                ]
+            }
+        },
+        "next": [
+            "DDF_GetIn_2_1"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 661,
+                "y": 267
+            }
+        }
+    },
+    "DDF_GetIn_2_1": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    27,
+                    104,
+                    181,
+                    527
+                ],
+                "expected": [
+                    "黑暗赛车界"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "DDF_GetIn_3_1"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 972,
+                "y": 285
+            }
+        }
+    },
+    "DDF_GetIn_3_1": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    1080,
+                    651,
+                    92,
+                    43
+                ],
+                "expected": [
+                    "开始比赛"
+                ]
+            }
+        },
+        "next": [
+            "DDF_Wait_副本5"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 1305,
+                "y": 160
+            }
+        }
+    },
+    "DDF_Wait_2_1": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    1039,
+                    21,
+                    128,
+                    127
+                ],
+                "expected": [
+                    "进度",
+                    "0",
+                    "时间",
+                    "名次"
+                ]
+            }
+        },
+        "post_delay": 15000,
+        "$__mpe_code": {
+            "position": {
+                "x": 1899,
+                "y": 40
+            }
+        }
+    },
+    "DDF_Wait_1_1": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    984,
+                    646,
+                    217,
+                    56
+                ],
+                "expected": [
+                    "离开"
+                ]
+            }
+        },
+        "next": [
+            "DDF_Wait_3_1",
+            "DDF_Finish"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 1908,
+                "y": 364
+            }
+        }
+    },
+    "DDF_Wait_3_1": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    519,
+                    453,
+                    260,
+                    184
+                ],
+                "expected": [
+                    "黑铁螺钉"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "timeout": 60000,
+        "next": [
+            "DDF_GetIn"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 2350,
+                "y": 593
+            }
+        }
+    },
+    "DDF_Wait_副本5": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    1080,
+                    651,
+                    92,
+                    43
+                ],
+                "expected": [
+                    "开始比赛"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "timeout": 200000,
+        "next": [
+            "DDF_Wait_1_1",
+            "[JumpBack]DDF_Wait_2_1"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 1594,
+                "y": 167
+            }
+        }
+    }
+}

--- a/assets/resource/base/pipeline/DeepDarkFantasy.json
+++ b/assets/resource/base/pipeline/DeepDarkFantasy.json
@@ -3,11 +3,11 @@
         "$__mpe_code": {
             "prefix": "",
             "coordinateMode": "absolute-v1",
-            "lastSyncTime": 1779981714527,
+            "lastSyncTime": 1779984028803,
             "isModifiedExternally": false,
             "filePath": "E:\\PyCharm\\Project\\GitMALostWord\\ddf\\assets\\resource\\base\\pipeline\\DeepDarkFantasy.json",
             "savedViewport": {
-                "x": -1436,
+                "x": -1696,
                 "y": -146,
                 "zoom": 0.99
             },
@@ -179,6 +179,7 @@
                 ]
             }
         },
+        "post_delay": 1000,
         "next": [
             "DDF_Wait_2_1",
             "DDF_Wait_2_2"
@@ -280,13 +281,15 @@
             "type": "OCR",
             "param": {
                 "roi": [
-                    547,
-                    460,
-                    181,
-                    165
+                    484,
+                    506,
+                    317,
+                    95
                 ],
                 "expected": [
-                    "今日黑铁螺钉已达上限，无法继续获得"
+                    "黑铁螺钉已达上限，无法继续获得",
+                    "已达上限",
+                    "无法继续获得"
                 ]
             }
         },

--- a/assets/resource/base/pipeline/DeepDarkFantasy.json
+++ b/assets/resource/base/pipeline/DeepDarkFantasy.json
@@ -3,13 +3,13 @@
         "$__mpe_code": {
             "prefix": "",
             "coordinateMode": "absolute-v1",
-            "lastSyncTime": 1779981712246,
+            "lastSyncTime": 1779981714527,
             "isModifiedExternally": false,
             "filePath": "E:\\PyCharm\\Project\\GitMALostWord\\ddf\\assets\\resource\\base\\pipeline\\DeepDarkFantasy.json",
             "savedViewport": {
-                "x": -949,
-                "y": 15,
-                "zoom": 0.75
+                "x": -1436,
+                "y": -146,
+                "zoom": 0.99
             },
             "filename": "DeepDarkFantasy",
             "version": "v1.5.3"
@@ -289,9 +289,6 @@
                     "今日黑铁螺钉已达上限，无法继续获得"
                 ]
             }
-        },
-        "action": {
-            "type": "Click"
         },
         "timeout": 60000,
         "$__mpe_code": {

--- a/assets/resource/base/pipeline/DeepDarkFantasy.json
+++ b/assets/resource/base/pipeline/DeepDarkFantasy.json
@@ -3,12 +3,12 @@
         "$__mpe_code": {
             "prefix": "",
             "coordinateMode": "absolute-v1",
-            "lastSyncTime": 1779979524577,
+            "lastSyncTime": 1779981712246,
             "isModifiedExternally": false,
             "filePath": "E:\\PyCharm\\Project\\GitMALostWord\\ddf\\assets\\resource\\base\\pipeline\\DeepDarkFantasy.json",
             "savedViewport": {
-                "x": -1102,
-                "y": -79,
+                "x": -949,
+                "y": 15,
                 "zoom": 0.75
             },
             "filename": "DeepDarkFantasy",
@@ -24,15 +24,6 @@
             "position": {
                 "x": -89,
                 "y": 255
-            }
-        }
-    },
-    "DDF_Finish": {
-        "focus": "完成",
-        "$__mpe_code": {
-            "position": {
-                "x": 2375,
-                "y": 311
             }
         }
     },
@@ -138,7 +129,7 @@
             }
         },
         "next": [
-            "DDF_Wait_副本5"
+            "DDF_Wait"
         ],
         "$__mpe_code": {
             "position": {
@@ -147,7 +138,7 @@
             }
         }
     },
-    "DDF_Wait_2_1": {
+    "DDF_Wait_1_2": {
         "recognition": {
             "type": "OCR",
             "param": {
@@ -189,8 +180,8 @@
             }
         },
         "next": [
-            "DDF_Wait_3_1",
-            "DDF_Finish"
+            "DDF_Wait_2_1",
+            "DDF_Wait_2_2"
         ],
         "$__mpe_code": {
             "position": {
@@ -199,7 +190,7 @@
             }
         }
     },
-    "DDF_Wait_3_1": {
+    "DDF_Wait_2_2": {
         "recognition": {
             "type": "OCR",
             "param": {
@@ -220,7 +211,7 @@
         "timeout": 60000,
         "next": [
             "DDF_GetIn",
-            "[JumpBack]DDF_Wait_1_1_副本1"
+            "[JumpBack]DDF_Wait_3_1"
         ],
         "$__mpe_code": {
             "position": {
@@ -229,7 +220,7 @@
             }
         }
     },
-    "DDF_Wait_副本5": {
+    "DDF_Wait": {
         "recognition": {
             "type": "OCR",
             "param": {
@@ -250,7 +241,7 @@
         "timeout": 200000,
         "next": [
             "DDF_Wait_1_1",
-            "[JumpBack]DDF_Wait_2_1"
+            "[JumpBack]DDF_Wait_1_2"
         ],
         "$__mpe_code": {
             "position": {
@@ -259,7 +250,7 @@
             }
         }
     },
-    "DDF_Wait_1_1_副本1": {
+    "DDF_Wait_3_1": {
         "recognition": {
             "type": "OCR",
             "param": {
@@ -279,8 +270,34 @@
         },
         "$__mpe_code": {
             "position": {
-                "x": 2656,
-                "y": 663
+                "x": 2701,
+                "y": 658
+            }
+        }
+    },
+    "DDF_Wait_2_1": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    547,
+                    460,
+                    181,
+                    165
+                ],
+                "expected": [
+                    "今日黑铁螺钉已达上限，无法继续获得"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click"
+        },
+        "timeout": 60000,
+        "$__mpe_code": {
+            "position": {
+                "x": 2330,
+                "y": 282
             }
         }
     }

--- a/assets/resource/tasks/DeepDarkFantasy.json
+++ b/assets/resource/tasks/DeepDarkFantasy.json
@@ -1,0 +1,12 @@
+{
+    "task": [
+        {
+            "name": "黑暗赛车界",
+            "label": "$黑暗赛车界",
+            "entry": "DDF_Action",
+            "option": [
+
+            ]
+        }
+    ]
+}

--- a/build.py
+++ b/build.py
@@ -591,9 +591,9 @@ def main():
         # 3. MaaFramework
         step_download_maa_framework(os_arch)
 
-        # # 4. MFAAvalonia
-        # if not skip_mfa:
-        #     step_download_mfa(os_arch, platform_tag)
+        # 4. MFAAvalonia
+        if not skip_mfa:
+            step_download_mfa(os_arch, platform_tag)
 
         # 5. MXU
         if not skip_mxu:
@@ -640,12 +640,12 @@ def main():
     if not args.skip_icon:
         step_copy_icons()
 
-    # # 打包
-    # if not skip_package:
-    #     if not skip_mfa:
-    #         step_package(platform_tag, args.tag, args.output_dir)
-    #     if not skip_mxu:
-    #         step_package(platform_tag, args.tag, args.output_dir, mxu=True)
+    # 打包
+    if not skip_package:
+        if not skip_mfa:
+            step_package(platform_tag, args.tag, args.output_dir)
+        if not skip_mxu:
+            step_package(platform_tag, args.tag, args.output_dir, mxu=True)
 
     print("\n" + "=" * 60)
     print("构建完成!")

--- a/build.py
+++ b/build.py
@@ -591,9 +591,9 @@ def main():
         # 3. MaaFramework
         step_download_maa_framework(os_arch)
 
-        # 4. MFAAvalonia
-        if not skip_mfa:
-            step_download_mfa(os_arch, platform_tag)
+        # # 4. MFAAvalonia
+        # if not skip_mfa:
+        #     step_download_mfa(os_arch, platform_tag)
 
         # 5. MXU
         if not skip_mxu:
@@ -640,12 +640,12 @@ def main():
     if not args.skip_icon:
         step_copy_icons()
 
-    # 打包
-    if not skip_package:
-        if not skip_mfa:
-            step_package(platform_tag, args.tag, args.output_dir)
-        if not skip_mxu:
-            step_package(platform_tag, args.tag, args.output_dir, mxu=True)
+    # # 打包
+    # if not skip_package:
+    #     if not skip_mfa:
+    #         step_package(platform_tag, args.tag, args.output_dir)
+    #     if not skip_mxu:
+    #         step_package(platform_tag, args.tag, args.output_dir, mxu=True)
 
     print("\n" + "=" * 60)
     print("构建完成!")


### PR DESCRIPTION
## Summary by Sourcery

在构建脚本中禁用与 MFA 相关的下载和打包步骤，并为新的 DeepDarkFantasy 任务流水线添加资源。

新特性：
- 为 DeepDarkFantasy 场景添加基础流水线和任务资源条目。

构建：
- 在构建工作流中注释掉 MFAAvalonia 的下载和打包步骤，仅保留 MXU 的打包流程处于启用状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable MFA-related download and packaging steps in the build script and add resources for a new DeepDarkFantasy task pipeline.

New Features:
- Add base pipeline and task resource entries for the DeepDarkFantasy scenario.

Build:
- Comment out MFAAvalonia download and packaging steps in the build workflow, leaving only MXU packaging active.

</details>