### PR TITLE
feat(PinkPawHeist): 增加粉爪策略二后台版本

### DIFF
--- a/agent/custom/action/pinkpaw/pinkpaw_bg_click.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_bg_click.py
@@ -1,0 +1,68 @@
+"""
+后台点击工具 - 通过 MAA controller.click() 发送点击
+使用 MAA 框架原生接口，不依赖 Windows 消息队列
+"""
+
+import json
+
+from maa.agent.agent_server import AgentServer
+from maa.custom_action import CustomAction
+from maa.context import Context
+
+
+def bg_click_at(context: Context, x: int, y: int) -> bool:
+    """通过 MAA controller.post_click() 点击指定坐标"""
+    job = context.tasker.controller.post_click(x, y)
+    job.wait()
+    return job.succeeded
+
+
+@AgentServer.custom_action("pinkpaw_bg_click")
+class PinkPawBGClick(CustomAction):
+    """
+    后台点击 custom action
+    优先点击 OCR 识别框的中心坐标（argv.box），
+    没有识别框时才使用 custom_action_param 里的固定坐标: {"x": 950, "y": 340}
+    """
+
+    def run(
+        self, context: Context, argv: CustomAction.RunArg
+    ) -> CustomAction.RunResult:
+        x, y = None, None
+
+        # 优先使用 OCR/识别框的中心坐标（Rect: x, y, w, h）
+        box = getattr(argv, 'box', None)
+        if box and hasattr(box, 'x') and hasattr(box, 'w') and box.w > 0:
+            x = int(box.x + box.w / 2)
+            y = int(box.y + box.h / 2)
+
+        # 没有识别框时，fallback 到 custom_action_param 里的固定坐标
+        if x is None or y is None:
+            param = {}
+            raw = argv.custom_action_param if hasattr(argv, 'custom_action_param') else None
+            if raw:
+                try:
+                    if isinstance(raw, dict):
+                        parsed = raw
+                    else:
+                        parsed = json.loads(raw)
+
+                    if isinstance(parsed, dict):
+                        # 情况3: 外层是完整param对象，x/y 在 custom_action_param 里
+                        if "custom_action_param" in parsed:
+                            inner = parsed["custom_action_param"]
+                            if isinstance(inner, str):
+                                inner = json.loads(inner)
+                            if isinstance(inner, dict):
+                                param = inner
+                        # 情况1/2: 直接就是 {"x": ..., "y": ...}
+                        elif "x" in parsed or "y" in parsed:
+                            param = parsed
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    pass
+
+            x = param.get("x", 640)
+            y = param.get("y", 360)
+
+        success = bg_click_at(context, x, y)
+        return CustomAction.RunResult(success=success)

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -109,6 +109,7 @@
         // group:HethereauHobbies
         "resource/tasks/Fish.json",
         "resource/tasks/PinkPawHeist.json",
+        "resource/tasks/PinkPawHeistBG.json",
         "resource/tasks/MakeCoffee.json",
         "resource/tasks/Rhythm.json",
         "resource/tasks/Tetris.json",

--- a/assets/resource/base/pipeline/PinkPawHeistBG.json
+++ b/assets/resource/base/pipeline/PinkPawHeistBG.json
@@ -1,0 +1,293 @@
+{
+    "PinkPawHeistBG_Main": {
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "DoNothing"
+        },
+        "next": [
+            "PinkPawHeistBG_Loop"
+        ],
+        "focus": {
+            "Node.Action.Starting": {
+                "content": "{name} 即将开始执行（后台模式），请确保你设置了**结束任务**的**全局快捷键**！",
+                "display": "modal"
+            }
+        }
+    },
+    "PinkPawHeistBG_Loop": {
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "DoNothing"
+        },
+        "next": [
+            {
+                "name": "PinkPawHeistBG_CoreSequence",
+                "jump_back": true
+            },
+            "PinkPawHeistBG_Finish"
+        ]
+    },
+    "PinkPawHeistBG_Finish": {
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "StopTask"
+        }
+    },
+    "PinkPawHeistBG_CoreSequence": {
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "DoNothing"
+        },
+        "next": [
+            "PinkPawHeistBG_DetectXiaoZhi",
+            "[JumpBack]SceneAnyEnterWorld"
+        ]
+    },
+    "PinkPawHeistBG_DetectXiaoZhi": {
+        "desc": "检测小吱交互按钮",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "^小",
+                    "(?i)Chiz",
+                    "ちぃちゃん",
+                    "치즈"
+                ],
+                "roi": [
+                    790,
+                    370,
+                    45,
+                    40
+                ],
+                "threshold": 0.1
+            }
+        },
+        "action": {
+            "type": "DoNothing"
+        },
+        "next": [
+            "PinkPawHeistBG_PressF_Interact"
+        ],
+        "on_error": [
+            "PinkPawHeistBG_StopTask"
+        ],
+        "focus": {
+            "Node.Action.Starting": {
+                "content": "（后台）开始寻找小吱",
+                "display": [
+                    "log",
+                    "toast"
+                ]
+            },
+            "Node.Action.Failed": {
+                "content": "❌ 未找到小吱，请确保在小吱面前开始任务",
+                "display": [
+                    "log",
+                    "toast"
+                ]
+            },
+            "Node.Action.Succeeded": {
+                "content": "✅ 成功找到小吱，开始后台任务",
+                "display": [
+                    "log",
+                    "toast"
+                ]
+            }
+        }
+    },
+    "PinkPawHeistBG_StopTask": {
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "StopTask"
+        }
+    },
+    "PinkPawHeistBG_PressF_Interact": {
+        "desc": "按F与小吱交互",
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": 70
+            }
+        },
+        "post_delay": 500,
+        "next": [
+            "PinkPawHeistBG_JoinByF"
+        ]
+    },
+    "PinkPawHeistBG_JoinByF": {
+        "desc": "后台版：等待对话框出现后按F选择'我要参加'",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "我加入。",
+                    "(?i)Count\\s*me\\s*in\\s*\\.",
+                    "参加する",
+                    "我要参加",
+                    "I'm in",
+                    "참가하기"
+                ],
+                "roi": [
+                    910,
+                    325,
+                    70,
+                    25
+                ],
+                "roi_offset": [
+                    0,
+                    0,
+                    18,
+                    0
+                ]
+            }
+        },
+        "pre_delay": 500,
+        "action": {
+            "type": "ClickKey",
+            "param": {
+                "key": 70
+            }
+        },
+        "next": [
+            "PinkPawHeistBG_SkipStory"
+        ]
+    },
+    "PinkPawHeistBG_SkipStory": {
+        "desc": "跳过废话（后台点击，重复3次确保跳过）",
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "pinkpaw_bg_click",
+                "custom_action_param": {
+                    "x": 950,
+                    "y": 340
+                }
+            }
+        },
+        "pre_delay": 2000,
+        "post_delay": 800,
+        "repeat": 3,
+        "repeat_delay": 800,
+        "next": [
+            "PinkPawHeistBG_AfterStory"
+        ]
+    },
+    "PinkPawHeistBG_AfterStory": {
+        "desc": "详情页，点进入按钮（后台点击）",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "进入",
+                    "進入",
+                    "(?i)Enter",
+                    "入る",
+                    "들어가기"
+                ],
+                "roi": [
+                    790,
+                    600,
+                    420,
+                    80
+                ]
+            }
+        },
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "pinkpaw_bg_click",
+                "custom_action_param": "{\"x\": 985, \"y\": 637}"
+            }
+        },
+        "post_delay": 1000,
+        "timeout": 60000,
+        "next": [
+            "PinkPawHeistBG_WaitReward",
+            "[JumpBack]RealTimeSkipStoryDialog",
+            "[JumpBack]RealTimeSkipStory"
+        ]
+    },
+    "PinkPawHeistBG_WaitReward": {
+        "desc": "等待进地图",
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "本局收益",
+                    "(?i)Round\\s*Earnings",
+                    "今回の収益",
+                    "본 라운드 수익"
+                ],
+                "roi": [
+                    30,
+                    250,
+                    100,
+                    20
+                ]
+            }
+        },
+        "action": {
+            "type": "DoNothing"
+        },
+        "next": [
+            "PinkPawHeistBG_ExecuteScheme"
+        ],
+        "on_error": [
+            "PinkPawHeistBG_WaitReward_Delay"
+        ],
+        "focus": {
+            "Node.Action.Starting": {
+                "content": "（后台）等待进入地图……",
+                "display": [
+                    "log",
+                    "toast"
+                ]
+            },
+            "Node.Action.Succeeded": {
+                "content": "✅ 成功进入地图（后台模式）",
+                "display": [
+                    "log",
+                    "toast"
+                ]
+            }
+        }
+    },
+    "PinkPawHeistBG_WaitReward_Delay": {
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "DoNothing"
+        },
+        "post_delay": 2000,
+        "next": [
+            "PinkPawHeistBG_WaitReward"
+        ]
+    },
+    "PinkPawHeistBG_ExecuteScheme": {
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "DoNothing"
+        },
+        "next": []
+    }
+}

--- a/assets/resource/tasks/PinkPawHeistBG.json
+++ b/assets/resource/tasks/PinkPawHeistBG.json
@@ -1,0 +1,87 @@
+{
+    "task": [
+        {
+            "name": "PinkPawHeistBG",
+            "label": "粉爪大劫案（后台）",
+            "entry": "PinkPawHeistBG_Main",
+            "description": "后台版自动刷取粉爪大劫案，使用<span style='color:green'>&ldquo;桌面端-后台&rdquo;</span>控制器。<br><span style='color:green'>建议启动后将游戏窗口最小化，避免鼠标干扰画面。</span><br><span style='color:orange'>注意：ALT键会中断WASD移动，运行期间请勿按ALT。</span>",
+            "option": [
+                "PinkPawHeistBG_Loop",
+                "PinkPawHeistBG_Scheme"
+            ],
+            "controller": [
+                "Win32-Background"
+            ],
+            "group": [
+                "HethereauHobbies"
+            ]
+        }
+    ],
+    "option": {
+        "PinkPawHeistBG_Loop": {
+            "type": "switch",
+            "label": "无限循环",
+            "description": "无限循环，直到手动结束任务。",
+            "default_case": "Yes",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "label": "开启"
+                },
+                {
+                    "name": "No",
+                    "label": "关闭",
+                    "option": [
+                        "PinkPawHeistBG_LoopCount"
+                    ]
+                }
+            ]
+        },
+        "PinkPawHeistBG_LoopCount": {
+            "type": "input",
+            "label": "循环次数",
+            "inputs": [
+                {
+                    "name": "count",
+                    "label": "循环次数",
+                    "default": "10",
+                    "pipeline_type": "int",
+                    "verify": "^[1-9]\\d{0,3}$"
+                }
+            ],
+            "pipeline_override": {
+                "PinkPawHeistBG_CoreSequence": {
+                    "max_hit": "{count}"
+                }
+            }
+        },
+        "PinkPawHeistBG_Scheme": {
+            "type": "select",
+            "label": "地图方案",
+            "description": "选择本次战斗的地图移动方案。",
+            "default_case": "Core2",
+            "cases": [
+                {
+                    "name": "Core2",
+                    "label": "方案二（推荐）",
+                    "pipeline_override": {
+                        "PinkPawHeistBG_ExecuteScheme": {
+                            "next": [
+                                "PinkPawHeist_Scheme2"
+                            ]
+                        }
+                    },
+                    "option": [
+                        "PinkPawHeistBG_Scheme_Core2_desc"
+                    ]
+                }
+            ]
+        },
+        "PinkPawHeistBG_Scheme_Core2_desc": {
+            "type": "input",
+            "label": "方案二说明",
+            "description": "<span style='color:orange'>后台版：请设置画质到性能档位，帧率设置120帧，关闭设置里的移动镜头修正！到小吱旁边启动！</span><br><span style='color:green'>配队要求：</span>1娜娜莉2任意位3早雾4狼（没有娜娜莉可换埃德加）<br><span style='color:green'>路线说明：</span>走藏品层路线撤离<br><span style='color:green'>启动建议：</span>启动后请将游戏窗口最小化，框架会自动以伪最小化方式继续截图，避免鼠标干扰",
+            "inputs": []
+        }
+    }
+}


### PR DESCRIPTION
## 概述

增加粉爪大劫案策略二的后台版本，使用 Win32-Background 控制器，支持窗口最小化运行。

## 改动内容

- 新增 `PinkPawHeistBG` 后台版任务定义和 pipeline
- 新增 `pinkpaw_bg_click` custom action（后台点击）
- `interface.json` 添加后台版任务 import
- 后台控制器 screencap 改为 Background（FramePool+PrintWindow），支持伪最小化

## 使用说明

- 选择"桌面端-后台"控制器时自动显示后台版任务
- 建议启动后将游戏窗口最小化，框架会以伪最小化方式继续截图

## Summary by Sourcery

使用 Win32-Background 控制器以及相应的任务/流水线定义，添加支持后台运行的 PinkPawHeist 策略版本。

新功能：
- 引入 PinkPawHeistBG 后台任务和流水线定义，用于在后台控制器下运行 heist 策略。
- 添加 `pinkpaw_bg_click` 自定义动作，基于 OCR 识别框或备用坐标，通过 `controller.post_click` 执行后台点击。

改进：
- 将新的 PinkPawHeistBG 后台任务接入全局接口配置，使其在使用桌面后台控制器时可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a background-capable version of the PinkPawHeist strategy using the Win32-Background controller and corresponding task/pipeline definitions.

New Features:
- Introduce the PinkPawHeistBG background task and pipeline definitions for running the heist strategy with a background controller.
- Add the pinkpaw_bg_click custom action to perform background clicks using controller.post_click based on OCR boxes or fallback coordinates.

Enhancements:
- Wire the new PinkPawHeistBG background task into the global interface configuration so it becomes available when using desktop background controllers.

</details>