### PR TITLE
chore: 更新workflow，自动在release note最后追加下载链接

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -1,6 +1,6 @@
 [remote.github]
-owner = "MaaXYZ"
-repo = "MaaPracticeBoilerplate"
+owner = "1bananachicken"
+repo = "MaaNTE"
 #自用时换成自己的仓库owner和repo
 #注意，本地git user需与github一致才能实现成功@
 [changelog]
@@ -62,6 +62,11 @@ body = """
 
 # 尾部
 footer = """
+## 国内下载源
+
+* [已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)
+* [夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)
+* [百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)
 """
 
 [git]

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -236,10 +236,12 @@ jobs:
           name: MaaNTE-win-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}-MXU
           path: "install-mxu"
 
-  release:
-    if: ${{ needs.meta.outputs.is_release == 'true' }}
-    needs: [meta, windows]
+  changelog:
+    name: Generate changelog
+    needs: meta
     runs-on: ubuntu-latest
+    outputs:
+      release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -260,10 +262,13 @@ jobs:
           OUTPUT: CHANGES.md
           GITHUB_REPO: ${{ github.repository }}
 
+  release:
+    if: ${{ needs.meta.outputs.is_release == 'true' }}
+    needs: [meta, windows, changelog]
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: MaaNTE-*
-          merge-multiple: false
           path: assets
 
       - name: Process and package artifacts
@@ -306,22 +311,13 @@ jobs:
             fi
           done
 
-      - name: Release
-        uses: softprops/action-gh-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: softprops/action-gh-release@v2.2.2
         with:
           files: assets/*
           tag_name: ${{ needs.meta.outputs.tag }}
-          body: |
-            ${{ steps.git-cliff.outputs.content }}
-
-            [已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)
-            [夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)
-            [百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)
+          body: ${{ needs.changelog.outputs.release_body }}
           draft: false
           prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
-          make_latest: ${{ needs.meta.outputs.is_prerelease == 'false' }}
 
       - name: Trigger MirrorChyanUploading
         shell: bash

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -266,52 +266,55 @@ jobs:
           RELEASE_BODY: ${{ steps.git-cliff.outputs.content }}
         run: |
           printf '%s\n\n' "$RELEASE_BODY" > release-note.md
-          cat <<'EOF' >> release-note.md
-          [已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)
-          [夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)
-          [百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)
-          EOF
+          echo '[已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)' >> release-note.md
+          echo '[夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)' >> release-note.md
+          echo '[百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)' >> release-note.md
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: release-note-${{ needs.meta.outputs.tag }}
-          path: release-note.md
-
-  preview_release_note:
-    name: Preview release note
-    if: ${{ needs.meta.outputs.is_release != 'true' }}
-    needs: [meta, changelog]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: release-note-${{ needs.meta.outputs.tag }}
-          path: release-note
-
-      - name: Show release note preview
+      - name: Print release note preview
+        if: ${{ needs.meta.outputs.is_release != 'true' }}
         shell: bash
         run: |
-          {
-            echo '# Release note preview'
-            echo
-            cat release-note/release-note.md
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo '===== Release note preview ====='
+          cat release-note.md
+          echo '===== End release note preview ====='
 
   release:
     if: ${{ needs.meta.outputs.is_release == 'true' }}
     needs: [meta, windows, changelog]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff-release
+        with:
+          config: .github/cliff.toml
+          args: >-
+            -vv --latest --strip header
+            ${{ needs.meta.outputs.is_prerelease == 'false' && '--tag-pattern "^v[0-9]+\\.[0-9]+\\.[0-9]+$"' || '' }}
+        env:
+          OUTPUT: CHANGES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Build release note file
+        shell: bash
+        env:
+          RELEASE_BODY: ${{ steps.git-cliff-release.outputs.content }}
+        run: |
+          printf '%s\n\n' "$RELEASE_BODY" > release-note.md
+          echo '[已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)' >> release-note.md
+          echo '[夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)' >> release-note.md
+          echo '[百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)' >> release-note.md
+
       - uses: actions/download-artifact@v4
         with:
           pattern: MaaNTE-*
           merge-multiple: false
           path: assets
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: release-note-${{ needs.meta.outputs.tag }}
-          path: release-note
 
       - name: Process and package artifacts
         run: |
@@ -357,7 +360,7 @@ jobs:
         with:
           files: assets/*
           tag_name: ${{ needs.meta.outputs.tag }}
-          body_path: release-note/release-note.md
+          body_path: release-note.md
           draft: false
           prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -241,7 +241,7 @@ jobs:
     needs: meta
     runs-on: ubuntu-latest
     outputs:
-      release_body: ${{ steps.git-cliff.outputs.content }}
+      release_body: ${{ steps.append_release_footer.outputs.release_body }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -261,6 +261,45 @@ jobs:
         env:
           OUTPUT: CHANGES.md
           GITHUB_REPO: ${{ github.repository }}
+
+      - name: Append release download links
+        id: append_release_footer
+        shell: bash
+        env:
+          RELEASE_BODY: ${{ steps.git-cliff.outputs.content }}
+        run: |
+          {
+            echo 'release_body<<EOF'
+            printf '%s\n\n' "$RELEASE_BODY"
+            echo '[已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)'
+            echo '[夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)'
+            echo '[百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)'
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  preview_release_note:
+    name: Preview release note
+    if: ${{ needs.meta.outputs.is_release != 'true' }}
+    needs: [meta, changelog]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show release note preview
+        shell: bash
+        env:
+          RELEASE_BODY: ${{ needs.changelog.outputs.release_body }}
+        run: |
+          {
+            echo '# Release note preview'
+            echo
+            printf '%s\n' "$RELEASE_BODY"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          printf '%s\n' "$RELEASE_BODY" > release-note-preview.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-note-preview-${{ needs.meta.outputs.tag }}
+          path: release-note-preview.md
 
   release:
     if: ${{ needs.meta.outputs.is_release == 'true' }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -236,9 +236,9 @@ jobs:
           name: MaaNTE-win-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}-MXU
           path: "install-mxu"
 
-  changelog:
-    name: Generate changelog
-    needs: meta
+  release:
+    if: ${{ needs.meta.outputs.is_release == 'true' }}
+    needs: [meta, windows]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -259,56 +259,6 @@ jobs:
         env:
           OUTPUT: CHANGES.md
           GITHUB_REPO: ${{ github.repository }}
-
-      - name: Build release note file
-        shell: bash
-        env:
-          RELEASE_BODY: ${{ steps.git-cliff.outputs.content }}
-        run: |
-          printf '%s\n\n' "$RELEASE_BODY" > release-note.md
-          echo '[已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)' >> release-note.md
-          echo '[夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)' >> release-note.md
-          echo '[百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)' >> release-note.md
-
-      - name: Print release note preview
-        if: ${{ needs.meta.outputs.is_release != 'true' }}
-        shell: bash
-        run: |
-          echo '===== Release note preview ====='
-          cat release-note.md
-          echo '===== End release note preview ====='
-
-  release:
-    if: ${{ needs.meta.outputs.is_release == 'true' }}
-    needs: [meta, windows, changelog]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate a changelog
-        uses: orhun/git-cliff-action@v4
-        id: git-cliff-release
-        with:
-          config: .github/cliff.toml
-          args: >-
-            -vv --latest --strip header
-            ${{ needs.meta.outputs.is_prerelease == 'false' && '--tag-pattern "^v[0-9]+\\.[0-9]+\\.[0-9]+$"' || '' }}
-        env:
-          OUTPUT: CHANGES.md
-          GITHUB_REPO: ${{ github.repository }}
-
-      - name: Build release note file
-        shell: bash
-        env:
-          RELEASE_BODY: ${{ steps.git-cliff-release.outputs.content }}
-        run: |
-          printf '%s\n\n' "$RELEASE_BODY" > release-note.md
-          echo '[已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)' >> release-note.md
-          echo '[夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)' >> release-note.md
-          echo '[百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)' >> release-note.md
 
       - uses: actions/download-artifact@v4
         with:
@@ -356,13 +306,22 @@ jobs:
             fi
           done
 
-      - uses: softprops/action-gh-release@v2.2.2
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: assets/*
           tag_name: ${{ needs.meta.outputs.tag }}
-          body_path: release-note.md
+          body: |
+            ${{ steps.git-cliff.outputs.content }}
+
+            [已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)
+            [夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)
+            [百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)
           draft: false
           prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
+          make_latest: ${{ needs.meta.outputs.is_prerelease == 'false' }}
 
       - name: Trigger MirrorChyanUploading
         shell: bash

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -240,8 +240,6 @@ jobs:
     name: Generate changelog
     needs: meta
     runs-on: ubuntu-latest
-    outputs:
-      release_body: ${{ steps.append_release_footer.outputs.release_body }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -262,20 +260,22 @@ jobs:
           OUTPUT: CHANGES.md
           GITHUB_REPO: ${{ github.repository }}
 
-      - name: Append release download links
-        id: append_release_footer
+      - name: Build release note file
         shell: bash
         env:
           RELEASE_BODY: ${{ steps.git-cliff.outputs.content }}
         run: |
-          {
-            echo 'release_body<<EOF'
-            printf '%s\n\n' "$RELEASE_BODY"
-            echo '[已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)'
-            echo '[夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)'
-            echo '[百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)'
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+          printf '%s\n\n' "$RELEASE_BODY" > release-note.md
+          cat <<'EOF' >> release-note.md
+          [已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)
+          [夸克网盘](https://pan.quark.cn/s/9eb393a6c95e?pwd=8nuf)
+          [百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu)
+          EOF
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-note-${{ needs.meta.outputs.tag }}
+          path: release-note.md
 
   preview_release_note:
     name: Preview release note
@@ -283,23 +283,19 @@ jobs:
     needs: [meta, changelog]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-note-${{ needs.meta.outputs.tag }}
+          path: release-note
+
       - name: Show release note preview
         shell: bash
-        env:
-          RELEASE_BODY: ${{ needs.changelog.outputs.release_body }}
         run: |
           {
             echo '# Release note preview'
             echo
-            printf '%s\n' "$RELEASE_BODY"
+            cat release-note/release-note.md
           } >> "$GITHUB_STEP_SUMMARY"
-
-          printf '%s\n' "$RELEASE_BODY" > release-note-preview.md
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: release-note-preview-${{ needs.meta.outputs.tag }}
-          path: release-note-preview.md
 
   release:
     if: ${{ needs.meta.outputs.is_release == 'true' }}
@@ -308,7 +304,14 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
+          pattern: MaaNTE-*
+          merge-multiple: false
           path: assets
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-note-${{ needs.meta.outputs.tag }}
+          path: release-note
 
       - name: Process and package artifacts
         run: |
@@ -354,7 +357,7 @@ jobs:
         with:
           files: assets/*
           tag_name: ${{ needs.meta.outputs.tag }}
-          body: ${{ needs.changelog.outputs.release_body }}
+          body_path: release-note/release-note.md
           draft: false
           prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
 


### PR DESCRIPTION
## Summary by Sourcery

更新发布工作流，在发布说明中追加下载链接，并在非正式发布运行时提供预览构件（artifact）。

新功能：
- 在安装工作流中，自动将预定义的下载链接追加到生成的发布说明中。
- 当工作流并非针对实际发布运行时，生成并上传发布说明的 Markdown 预览。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the release workflow to append download links to release notes and provide a preview artifact for non-release runs.

New Features:
- Automatically append predefined download links to the generated release notes in the install workflow.
- Generate and upload a markdown preview of the release note when the workflow is not running for an actual release.

</details>