### PR TITLE
chore: auto-close invalid issue forms

### DIFF
--- a/.github/workflows/close-invalid-issues.yml
+++ b/.github/workflows/close-invalid-issues.yml
@@ -1,0 +1,67 @@
+name: Close Invalid Issues
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  close-invalid-issue:
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues with invalid confirmation checked
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- maa-auto-close-invalid-checkbox -->';
+            const invalidPatterns = [
+              /(?:^|\n)\s*-\s*\[[xX]\]\s*我未确认下列内容，仅仅是点了确认\s*(?:\n|$)/,
+              /(?:^|\n)\s*-\s*\[[xX]\]\s*I did not confirm the following content;\s*I simply clicked ["“]confirm\.[”"]\s*(?:\n|$)/i,
+            ];
+
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+            const shouldClose = invalidPatterns.some((pattern) => pattern.test(body));
+
+            if (!shouldClose) {
+              core.info('No invalid confirmation checkbox was checked.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = issue.number;
+            const commentBody = [
+              marker,
+              '该 Issue 勾选了“未确认下列内容，仅仅是点了确认”确认项，按模板规则自动关闭。',
+              '',
+              'This issue checked the invalid confirmation option ("I did not confirm the following content; I simply clicked confirm.") and has been closed automatically.',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const alreadyCommented = comments.some((comment) => comment.body?.includes(marker));
+            if (!alreadyCommented) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: commentBody,
+              });
+            }
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });

--- a/.github/workflows/close-invalid-issues.yml
+++ b/.github/workflows/close-invalid-issues.yml
@@ -24,6 +24,11 @@ jobs:
             ];
 
             const issue = context.payload.issue;
+            if (issue.state === 'closed') {
+              core.info('Issue is already closed; skipping.');
+              return;
+            }
+
             const body = issue.body || '';
             const shouldClose = invalidPatterns.some((pattern) => pattern.test(body));
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that detects the invalid confirmation checkbox in issue forms
- automatically comments once and closes those issues as not planned
- supports the Chinese and English invalid confirmation checkbox text

## Test
- verified checkbox matching logic locally
- ran git diff --check for the workflow file

## Summary by Sourcery

CI:
- 引入一个 GitHub Actions 工作流，用于检测具有无效确认复选框（英文或中文）的议题，只发布一次解释性评论，并将其关闭为“不予规划”。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Introduce a GitHub Actions workflow that detects issues with an invalid confirmation checkbox (in English or Chinese), posts an explanatory comment once, and closes them as not planned.

</details>