### PR TITLE
docs: 整理 README 并同步 i18n 翻译

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@
 >
 > 本项目还处于早期开发阶段，欢迎提交 PR 和 Issue。
 >
-> 下载、文档与问题排查请访问 **[官方网站 docs.maante.org](https://docs.maante.org/)**。加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，系统会自动分配当前未满的群号。
+> 下载、文档与问题排查请访问 [官方网站](https://docs.maante.org/)。
 >
-> 其他渠道： [B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
+> 加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，会自动分配当前未满的群号。
+>
+> 其他渠道：[B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
 ## ⚠️免责声明与风险提示
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@
 >
 > 本项目还处于早期开发阶段，欢迎提交 PR 和 Issue。
 >
-> 下载、文档与问题排查请访问 **[官方网站 docs.maante.org](https://docs.maante.org/)**；加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，会自动分配当前未满的群号。
+> 下载、文档与问题排查请访问 **[官方网站 docs.maante.org](https://docs.maante.org/)**。加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，系统会自动分配当前未满的群号。
 >
-> 其他渠道：[B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
+> 其他渠道： [B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
 ## ⚠️免责声明与风险提示
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
   <p align="center">
     MAA异环小助手
     <br/>
+    <a href="https://docs.maante.org/"><strong>官方网站</strong></a>
+    ·
     <a href="./docs/eng/README_en.md">English</a> | <a href="./docs/README_zh-tw.md">繁體中文</a> | <a href="./docs/jp/README_jp.md">日本語</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">报告 Bug</a>
   </p>
   <p align="center">
@@ -14,6 +16,7 @@
     <img src="https://img.shields.io/badge/Language-Python%20%2F%20PipeLine-blue?style=flat-square&logo=Python" alt="Language" />
     <img alt="license" src="https://img.shields.io/github/license/1bananachicken/MaaNTE?style=flat-square">
     <br>
+    <a href="https://docs.maante.org/" target="_blank"><img alt="website" src="https://img.shields.io/badge/Website-docs.maante.org-00A98F?style=flat-square"></a>
     <a href="https://maafw.com/" target="_blank"><img alt="website" src="https://raw.githubusercontent.com/MaaXYZ/MaaFramework/refs/heads/main/docs/static/maafw.svg"></a>
     <a href="https://mirrorchyan.com/zh/projects?rid=MaaNTE" target="_blank"><img alt="mirrorc" src="https://raw.githubusercontent.com/MaaXYZ/MaaFramework/refs/heads/main/docs/static/mirrorc-zh.svg"></a>
     <a href="https://space.bilibili.com/3546893080594665" target="_blank"><img alt="Bilibili" src="https://img.shields.io/badge/Bilibili-MaaNTE--Official-00A1D6?logo=bilibili"></a>
@@ -29,31 +32,17 @@
 
 > [!Caution]
 >
-> 近期出现大量账号二次分发本软件，甚至冒充官方账号。通过非官方途径获取的软件可能**含有病毒**，并且一般不是最新的版本，请注意甄别。
->
->近日，我们发现存在借本项目之名传播病毒的行为，请在下载时认准官方渠道。
+> 近期出现大量账号二次分发本软件，甚至冒充官方账号。通过非官方途径获取的软件可能**含有病毒**，并且一般不是最新版本。请务必从 [GitHub Releases](https://github.com/1bananachicken/MaaNTE/releases) 等官方渠道下载。
 
 > [!Tip]
 >
-> 本项目还处于早期开发阶段，欢迎提交PR和Issue
+> 本项目还处于早期开发阶段，欢迎提交 PR 和 Issue。
+>
+> 下载、文档与问题排查请访问 **[官方网站 docs.maante.org](https://docs.maante.org/)**；加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，会自动分配当前未满的群号。
+>
+> 其他渠道：[B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
-> [!Tip]
->
-> 官方 B 站账号: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
->
-> 官方网站: [MaaNTE文档站](https://docs.maante.org/)
->
-> QQ交流1群: 1103323319
->
-> QQ交流2群: 1101147419
->
-> QQ交流3群: 1075143235
->
-> QQ交流4群: 713114598
->
-> QQ交流5群: 1106448578
-
-# ⚠️免责声明与风险提示
+## ⚠️免责声明与风险提示
 
 > [!Note]
 >
@@ -97,14 +86,15 @@
 - 🕛 实时辅助
   - 🗼 自动传送
   - ⏩ 自动跳剧情
+  - 🎁 自动拾取
 - ⚔️ 自动闪避
   - 🛡️ 基于音频识别的自动闪避/反击
 - 🎵 自动超强音
   - 🥁 循环演奏迷星叫
 - 🎹 自动弹钢琴
-  - 📂 支持任意midi导入
+  - 📂 支持任意 MIDI 导入
 - 📋 预设任务组
-  - ⚡ 快速日常 / 📆 全套日常 / 💤 挂机任务 / 🗺️ 实时辅助
+  - 💤 挂机任务 / 🗺️ 实时辅助
 
 ## ❓常见问题
 
@@ -114,11 +104,11 @@
 
 ### 🤔找不到怎么启动？
 
-- 普通用户请下载release版本，有开发需求再clone仓库
+- 普通用户请下载 [Release 版本](https://github.com/1bananachicken/MaaNTE/releases)，有开发需求再 clone 仓库
 
 ## 💡注意事项
 
-游戏需要运行在1280x720分辨率，窗口化，钓鱼新算法支持120帧运行
+游戏需要运行在 1280×720 分辨率、窗口化模式下；钓鱼新算法支持 120 帧运行。
 
 ## 💻开发指南
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@
 > 本项目还处于早期开发阶段，欢迎提交 PR 和 Issue。
 >
 > 下载、文档与问题排查请访问 [官方网站](https://docs.maante.org/)。
->
 > 加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，会自动分配当前未满的群号。
 >
-> 其他渠道：[B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
+> 其他渠道：
+> 官方 B 站账号: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
+>
+> 官方Discord: [Discord](https://discord.gg/e6mPMRYQpR)
 
 ## ⚠️免责声明与风险提示
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@
 > 本项目还处于早期开发阶段，欢迎提交 PR 和 Issue。
 >
 > 下载、文档与问题排查请访问 [官方网站](https://docs.maante.org/)。
+>
 > 加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，会自动分配当前未满的群号。
 >
-> 其他渠道：
 > 官方 B 站账号: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
 >
 > 官方Discord: [Discord](https://discord.gg/e6mPMRYQpR)

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@
 >
 > 本项目还处于早期开发阶段，欢迎提交 PR 和 Issue。
 >
-> 下载、文档与问题排查请访问 [官方网站](https://docs.maante.org/)。
+> 下载、文档与问题排查请访问 [官方网站](https://docs.maante.org/)
 >
-> 加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，会自动分配当前未满的群号。
+> 加入 QQ 交流群请前往 [官网 QQ 群页面](https://docs.maante.org/zh_cn/qq-group/)，会自动分配当前未满的群号
 >
 > 官方 B 站账号: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
 >

--- a/docs/README_zh-tw.md
+++ b/docs/README_zh-tw.md
@@ -7,6 +7,8 @@
   <p align="center">
     MAA異環小助手
     <br/>
+    <a href="https://docs.maante.org/"><strong>官方網站</strong></a>
+    ·
     <a href="/docs/eng/README_en.md">English</a> | <a href="/README.md">简体中文</a> | <a href="/docs/jp/README_jp.md">日本語</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">报告 Bug</a>
   </p>
 
@@ -15,6 +17,7 @@
     <img src="https://img.shields.io/badge/Language-Python%20%2F%20PipeLine-blue?style=flat-square&logo=Python" alt="Language" />
     <img alt="license" src="https://img.shields.io/github/license/1bananachicken/MaaNTE?style=flat-square">
     <br>
+    <a href="https://docs.maante.org/" target="_blank"><img alt="website" src="https://img.shields.io/badge/Website-docs.maante.org-00A98F?style=flat-square"></a>
     <a href="https://maafw.com/" target="_blank"><img alt="website" src="https://raw.githubusercontent.com/MaaXYZ/MaaFramework/refs/heads/main/docs/static/maafw.svg"></a>
     <a href="https://mirrorchyan.com/zh/projects?rid=MaaNTE" target="_blank"><img alt="mirrorc" src="https://raw.githubusercontent.com/MaaXYZ/MaaFramework/refs/heads/main/docs/static/mirrorc-zh.svg"></a>
     <a href="https://space.bilibili.com/3546893080594665" target="_blank"><img alt="Bilibili" src="https://img.shields.io/badge/Bilibili-MaaNTE--Official-00A1D6?logo=bilibili"></a>
@@ -30,30 +33,17 @@
 
 > [!Caution]
 >
-> 近期出現大量帳號二次分發本軟體，甚至冒充官方帳號。透過非官方途徑取得的軟體可能**含有病毒**，且通常不是最新版本，請注意辨別。
->
-> 近日，我們發現有人借本專案之名傳播病毒，請務必從官方管道下載。
+> 近期出現大量帳號二次分發本軟體，甚至冒充官方帳號。透過非官方途徑取得的軟體可能**含有病毒**，且通常不是最新版本。請務必從 [GitHub Releases](https://github.com/1bananachicken/MaaNTE/releases) 等官方管道下載。
 
 > [!Tip]
 >
-> 本專案仍處於早期開發階段，歡迎提交 PR 和 Issue
+> 本專案仍處於早期開發階段，歡迎提交 PR 和 Issue。
+>
+> 下載、文件與問題排查請造訪 **[官方網站 docs.maante.org](https://docs.maante.org/)**；加入 QQ 交流群請前往 [官網 QQ 群頁面](https://docs.maante.org/zh_cn/qq-group/)，會自動分配目前未滿的群號。
+>
+> 其他渠道：[B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
-> [!Tip]
->
-> 官方 B 站帳號：[MaaNTE-Official](https://space.bilibili.com/3546893080594665)
->
-> QQ交流1群：1103323319（已滿）
->
-> QQ交流2群：1101147419（已滿）
->
-> QQ交流3群：1075143235（已滿）
->
-> QQ交流4群：713114598（已滿）
->
-> QQ交流5群：1106448578
-
-
-# ⚠️免責聲明與風險提示
+## ⚠️免責聲明與風險提示
 
 > [!Note]
 >
@@ -80,18 +70,32 @@
   - 🪝 自動買魚餌
 - 🥤 自動做咖啡
   - 🔨 驅趕所有顧客
-- 💰 自動提取一咖舍收益
+- 💰 自動領取一咖舍收益
   - 📦 自動補貨
+  - 🏷️ 根據風向標自動替換商品
+- 🪑 自動收家具
+  - 🏠 支援維納/伊登/天景/金都/峰林五處公寓
 - 💎 自動領取獎勵
   - 🎁 活躍度
   - 📅 環期賞令
+- 🐾 粉爪大劫案
+  - 🔄 支援無限循環掛機
+  - 📊 收益統計與日誌記錄
+- 🧩 自動俄羅斯方塊
+  - 🤖 內建 AI 自動決策
+  - 🔁 自動連打直到活力耗盡
 - 🕛 即時輔助
   - 🗼 自動傳送
   - ⏩ 自動跳劇情
+  - 🎁 自動拾取
 - ⚔️ 自動閃避
   - 🛡️ 基於音訊辨識的自動閃避／反擊
 - 🎵 自動超強音
   - 🥁 循環演奏迷星叫
+- 🎹 自動彈鋼琴
+  - 📂 支援任意 MIDI 匯入
+- 📋 預設任務組
+  - 💤 掛機任務 / 🗺️ 即時輔助
 
 ## ❓常見問題
 
@@ -101,15 +105,15 @@
 
 ### 🤔找不到怎麼啟動？
 
-- 一般使用者請下載 release 版本，有開發需求再 clone 倉庫
+- 一般使用者請下載 [Release 版本](https://github.com/1bananachicken/MaaNTE/releases)，有開發需求再 clone 倉庫
 
 ## 💡注意事項
 
-遊戲需要在 1280×720 解析度下以視窗模式執行，釣魚新演算法支援 120 幀執行。
+遊戲需要在 1280×720 解析度下以視窗模式執行；釣魚新演算法支援 120 幀執行。
 
 ## 💻開發指南
 
-想參與開發或深入了解專案？來這裡吧 👉 [開發者文件索引](https://github.com/1bananachicken/MaaNTE/blob/dev/docs/zh_cn/develop/README.md)
+想參與開發或深入了解專案？來這裡吧 👉 [開發者文件索引](zh_cn/develop/README.md)
 
 歡迎各路大佬貢獻程式碼，一起讓 MaaNTE 變得更強！💪
 

--- a/docs/README_zh-tw.md
+++ b/docs/README_zh-tw.md
@@ -39,9 +39,13 @@
 >
 > 本專案仍處於早期開發階段，歡迎提交 PR 和 Issue。
 >
-> 下載、文件與問題排查請造訪 **[官方網站 docs.maante.org](https://docs.maante.org/)**；加入 QQ 交流群請前往 [官網 QQ 群頁面](https://docs.maante.org/zh_cn/qq-group/)，會自動分配目前未滿的群號。
+> 下載、文件與問題排查請造訪 **[官方網站 docs.maante.org](https://docs.maante.org/)**。
+> 加入 QQ 交流群請前往 [官網 QQ 群頁面](https://docs.maante.org/zh_cn/qq-group/)，會自動分配目前未滿的群號。
 >
-> 其他渠道：[B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
+> 其他渠道：
+> 官方 B 站帳號： [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
+>
+> 官方Discord： [Discord](https://discord.gg/e6mPMRYQpR)
 
 ### ⚠️免責聲明與風險提示
 

--- a/docs/README_zh-tw.md
+++ b/docs/README_zh-tw.md
@@ -37,11 +37,11 @@
 
 > [!Tip]
 >
-> 本專案仍處於早期開發階段，歡迎提交 PR 和 Issue。
+> 本專案仍處於早期開發階段，歡迎提交 PR 和 Issue
 >
-> 下載、文件與問題排查請造訪 **[官方網站 docs.maante.org](https://docs.maante.org/)**。
+> 下載、文件與問題排查請造訪 **[官方網站 docs.maante.org](https://docs.maante.org/)**
 >
-> 加入 QQ 交流群請前往 [官網 QQ 群頁面](https://docs.maante.org/zh_cn/qq-group/)，會自動分配目前未滿的群號。
+> 加入 QQ 交流群請前往 [官網 QQ 群頁面](https://docs.maante.org/zh_cn/qq-group/)，會自動分配目前未滿的群號
 >
 > 官方 B 站帳號： [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
 >

--- a/docs/README_zh-tw.md
+++ b/docs/README_zh-tw.md
@@ -40,9 +40,9 @@
 > 本專案仍處於早期開發階段，歡迎提交 PR 和 Issue。
 >
 > 下載、文件與問題排查請造訪 **[官方網站 docs.maante.org](https://docs.maante.org/)**。
+>
 > 加入 QQ 交流群請前往 [官網 QQ 群頁面](https://docs.maante.org/zh_cn/qq-group/)，會自動分配目前未滿的群號。
 >
-> 其他渠道：
 > 官方 B 站帳號： [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
 >
 > 官方Discord： [Discord](https://discord.gg/e6mPMRYQpR)

--- a/docs/README_zh-tw.md
+++ b/docs/README_zh-tw.md
@@ -9,7 +9,7 @@
     <br/>
     <a href="https://docs.maante.org/"><strong>官方網站</strong></a>
     ·
-    <a href="/docs/eng/README_en.md">English</a> | <a href="/README.md">简体中文</a> | <a href="/docs/jp/README_jp.md">日本語</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">报告 Bug</a>
+    <a href="../eng/README_en.md">English</a> | <a href="../README.md">简体中文</a> | <a href="../jp/README_jp.md">日本語</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">报告 Bug</a>
   </p>
 
   <p align="center">
@@ -43,7 +43,7 @@
 >
 > 其他渠道：[B 站 @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
-## ⚠️免責聲明與風險提示
+### ⚠️免責聲明與風險提示
 
 > [!Note]
 >
@@ -59,7 +59,7 @@
 >
 > **您應充分瞭解並自願承擔使用本工具可能帶來的所有風險。**
 
-## 🧾開源許可
+### 🧾開源許可
 
 本軟體使用 [GNU Affero General Public License v3.0 only](https://spdx.org/licenses/AGPL-3.0-only.html) 開源。
 
@@ -107,11 +107,11 @@
 
 - 一般使用者請下載 [Release 版本](https://github.com/1bananachicken/MaaNTE/releases)，有開發需求再 clone 倉庫
 
-## 💡注意事項
+### 💡注意事項
 
 遊戲需要在 1280×720 解析度下以視窗模式執行；釣魚新演算法支援 120 幀執行。
 
-## 💻開發指南
+### 💻開發指南
 
 想參與開發或深入了解專案？來這裡吧 👉 [開發者文件索引](zh_cn/develop/README.md)
 

--- a/docs/eng/README_en.md
+++ b/docs/eng/README_en.md
@@ -43,9 +43,13 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) !
 >
 > This project is still in early development. PRs and Issues are welcome.
 >
-> For downloads, docs, and troubleshooting, visit **[docs.maante.org](https://docs.maante.org/en_us/)**. To join a QQ group, use the [official QQ group page](https://docs.maante.org/zh_cn/qq-group/) — it automatically assigns you to a group that still has space.
+> For downloads, docs, and troubleshooting, visit **[docs.maante.org](https://docs.maante.org/en_us/)**.
+> To join a QQ group, use the [official QQ group page](https://docs.maante.org/zh_cn/qq-group/) — it automatically assigns you to a group that still has space.
 >
-> Other channels: [Bilibili @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
+> Other channels:
+> Official Bilibili account: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
+>
+> Official Discord: [Discord](https://discord.gg/e6mPMRYQpR)
 
 ### ⚠️ Disclaimer and Risk Notice
 

--- a/docs/eng/README_en.md
+++ b/docs/eng/README_en.md
@@ -7,7 +7,9 @@
   <p align="center">
     MAA Assistant for Neverness to Everness
     <br/>
-     <a href="/README.md">简体中文</a> | <a href="/docs/README_zh-tw.md">繁體中文</a> | <a href="/docs/jp/README_jp.md">日本語</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">报告 Bug</a>
+    <a href="https://docs.maante.org/en_us/"><strong>Official Website</strong></a>
+    ·
+     <a href="/README.md">简体中文</a> | <a href="/docs/README_zh-tw.md">繁體中文</a> | <a href="/docs/jp/README_jp.md">日本語</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">Report Bug</a>
   </p>
 
   <p align="center">
@@ -15,6 +17,7 @@
     <img src="https://img.shields.io/badge/Language-Python%20%2F%20PipeLine-blue?style=flat-square&logo=Python" alt="Language" />
     <img alt="license" src="https://img.shields.io/github/license/1bananachicken/MaaNTE?style=flat-square">
     <br>
+    <a href="https://docs.maante.org/en_us/" target="_blank"><img alt="website" src="https://img.shields.io/badge/Website-docs.maante.org-00A98F?style=flat-square"></a>
     <a href="https://maafw.com/" target="_blank"><img alt="website" src="https://raw.githubusercontent.com/MaaXYZ/MaaFramework/refs/heads/main/docs/static/maafw.svg"></a>
     <a href="https://mirrorchyan.com/zh/projects?rid=MaaNTE" target="_blank"><img alt="mirrorc" src="https://raw.githubusercontent.com/MaaXYZ/MaaFramework/refs/heads/main/docs/static/mirrorc-en.svg"></a>
     <a href="https://space.bilibili.com/3546893080594665" target="_blank"><img alt="Bilibili" src="https://img.shields.io/badge/Bilibili-MaaNTE--Official-00A1D6?logo=bilibili"></a>
@@ -34,28 +37,17 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) !
 
 > [!Caution]
 >
-> Recently, a large number of accounts have been redistributing this software, even impersonating official accounts. Software obtained through unofficial channels **may contain viruses** and is generally not the latest version. Please verify carefully.
->
-> We have recently discovered that some individuals are using this project to spread viruses. Please make sure to download only from the official channels.
+> Recently, many accounts have been redistributing this software or impersonating official accounts. Software obtained through unofficial channels **may contain viruses** and is often not the latest version. Please download only from [GitHub Releases](https://github.com/1bananachicken/MaaNTE/releases) or other official channels.
 
 > [!Tip]
 >
 > This project is still in early development. PRs and Issues are welcome.
+>
+> For downloads, docs, and troubleshooting, visit **[docs.maante.org](https://docs.maante.org/en_us/)**. To join a QQ group, use the [official QQ group page](https://docs.maante.org/zh_cn/qq-group/) — it automatically assigns you to a group that still has space.
+>
+> Other channels: [Bilibili @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
-> [!Tip]
->
-> Official Bilibili account: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
->
-> QQ Group 1: 1103323319 (Full)
->
-> QQ Group 2: 1101147419 (Full)
->
-> QQ Group 3: 1075143235 (Full)
->
-> QQ Group 4: 713114598 (Full)
->
-> QQ Group 5: 1106448578
-# Disclaimer and Risk Notice
+## ⚠️ Disclaimer and Risk Notice
 
 > [!Note]
 >
@@ -71,11 +63,11 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) !
 >
 > **You should fully understand and voluntarily bear all risks that may arise from using this tool.**
 
-## 📄Open Source License
+## 🧾 Open Source License
 
 This software is open-sourced under [GNU Affero General Public License v3.0 only](https://spdx.org/licenses/AGPL-3.0-only.html).
 
-## ✨Features
+## ✨ Features
 
 - 🎣 Auto Fishing
   - 🐟 Auto Sell Fish
@@ -99,6 +91,7 @@ This software is open-sourced under [GNU Affero General Public License v3.0 only
 - 🕛 Real-time Assistance
   - 🗼 Auto Teleport
   - ⏩ Auto Skip Story
+  - 🎁 Auto Loot
 - ⚔️ Auto Dodge
   - 🛡️ Audio-based auto dodge/counter
 - 🎵 Auto Rhythm Game
@@ -106,29 +99,29 @@ This software is open-sourced under [GNU Affero General Public License v3.0 only
 - 🎹 Auto Piano
   - 📂 Supports custom MIDI import
 - 📋 Task Presets
-  - ⚡ Quick Daily / 📆 Full Daily / 💤 AFK / 🗺️ Real-time Assist
+  - 💤 AFK / 🗺️ Real-time Assist
 
-## ❓FAQ
+## ❓ FAQ
 
-### 📄Troubleshooting
+### 📄 Troubleshooting
 
-Please refer to the [Trouble shooting Guide](../eng/trouble_shooting.md) (English).
+Please refer to the [Troubleshooting Guide](../eng/trouble_shooting.md) (English).
 
-### 🤔Can't find how to start?
+### 🤔 Can't find how to start?
 
-- Regular users please download the release version. Only clone the repository if you plan to develop.
+- Regular users should download the [Release version](https://github.com/1bananachicken/MaaNTE/releases). Only clone the repository if you plan to develop.
 
-## 💡Notes
+## 💡 Notes
 
 The game must run in windowed mode at 1280×720 resolution. The new fishing algorithm supports 120 FPS.
 
-## 💻Development Guide
+## 💻 Development Guide
 
-Want to contribute or dive deeper into the project? Start here 👉 [Developer Documentation Index](https://github.com/1bananachicken/MaaNTE/blob/dev/docs/zh_cn/develop/README.md)
+Want to contribute or dive deeper into the project? Start here 👉 [Developer Documentation Index](../zh_cn/develop/README.md)
 
 All contributions are welcome — let's make MaaNTE even better together! 💪
 
-## ☕Acknowledgements
+## ❤️ Acknowledgements
 
 ### Open Source Projects
 
@@ -151,7 +144,7 @@ Thanks to all the developers who participated in testing and development (´▽`
 
 [![Contributors](https://contributors-img.web.app/image?repo=1bananachicken/MaaNTE&max=1000)](https://github.com/1bananachicken/MaaNTE/graphs/contributors)
 
-## ☕Buy Us a Coffee
+## ☕ Buy Us a Coffee
 
 If MaaNTE has saved you a lot of time, how about buying the developers a coffee?
 
@@ -159,7 +152,7 @@ Your support is our biggest motivation to keep updating! 🥰
 
 [<img width="200" alt="Sponsor Us" src="https://pic1.afdiancdn.com/static/img/welcome/button-sponsorme.png">](https://afdian.com/a/MaaNTE)
 
-## ⭐Star History
+## ⭐ Star History
 
 If you find this software helpful, please give us a Star! (the little star at the top right of the page) – that's the greatest support for us!
 

--- a/docs/eng/README_en.md
+++ b/docs/eng/README_en.md
@@ -44,9 +44,9 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) !
 > This project is still in early development. PRs and Issues are welcome.
 >
 > For downloads, docs, and troubleshooting, visit **[docs.maante.org](https://docs.maante.org/en_us/)**.
+>
 > To join a QQ group, use the [official QQ group page](https://docs.maante.org/zh_cn/qq-group/) — it automatically assigns you to a group that still has space.
 >
-> Other channels:
 > Official Bilibili account: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
 >
 > Official Discord: [Discord](https://discord.gg/e6mPMRYQpR)

--- a/docs/eng/README_en.md
+++ b/docs/eng/README_en.md
@@ -7,9 +7,9 @@
   <p align="center">
     MAA Assistant for Neverness to Everness
     <br/>
-    <a href="https://docs.maante.org/en_us/"><strong>Official Website</strong></a>
+    <a href="https://docs.maante.org/"><strong>Official Website</strong></a>
     ·
-     <a href="/README.md">简体中文</a> | <a href="/docs/README_zh-tw.md">繁體中文</a> | <a href="/docs/jp/README_jp.md">日本語</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">Report Bug</a>
+     <a href="../README.md">简体中文</a> | <a href="../README_zh-tw.md">繁體中文</a> | <a href="../jp/README_jp.md">日本語</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">Report Bug</a>
   </p>
 
   <p align="center">
@@ -47,7 +47,7 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) !
 >
 > Other channels: [Bilibili @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
-## ⚠️ Disclaimer and Risk Notice
+### ⚠️ Disclaimer and Risk Notice
 
 > [!Note]
 >
@@ -63,7 +63,7 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) !
 >
 > **You should fully understand and voluntarily bear all risks that may arise from using this tool.**
 
-## 🧾 Open Source License
+### 🧾 Open Source License
 
 This software is open-sourced under [GNU Affero General Public License v3.0 only](https://spdx.org/licenses/AGPL-3.0-only.html).
 
@@ -111,11 +111,11 @@ Please refer to the [Troubleshooting Guide](../eng/trouble_shooting.md) (English
 
 - Regular users should download the [Release version](https://github.com/1bananachicken/MaaNTE/releases). Only clone the repository if you plan to develop.
 
-## 💡 Notes
+### 💡 Notes
 
 The game must run in windowed mode at 1280×720 resolution. The new fishing algorithm supports 120 FPS.
 
-## 💻 Development Guide
+### 💻 Development Guide
 
 Want to contribute or dive deeper into the project? Start here 👉 [Developer Documentation Index](../zh_cn/develop/README.md)
 

--- a/docs/eng/README_en.md
+++ b/docs/eng/README_en.md
@@ -43,9 +43,9 @@ Powered by [MaaFramework](https://github.com/MaaXYZ/MaaFramework) !
 >
 > This project is still in early development. PRs and Issues are welcome.
 >
-> For downloads, docs, and troubleshooting, visit **[docs.maante.org](https://docs.maante.org/en_us/)**.
+> For downloads, docs, and troubleshooting, visit **[docs.maante.org](https://docs.maante.org/en_us/)**
 >
-> To join a QQ group, use the [official QQ group page](https://docs.maante.org/zh_cn/qq-group/) — it automatically assigns you to a group that still has space.
+> To join a QQ group, use the [official QQ group page](https://docs.maante.org/zh_cn/qq-group/) — it automatically assigns you to a group that still has space
 >
 > Official Bilibili account: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
 >

--- a/docs/eng/trouble_shooting.md
+++ b/docs/eng/trouble_shooting.md
@@ -1,102 +1,79 @@
-# MaaNTE Troubleshooting Guide
+# MaaNTE Problem Troubleshooting Guide
+This text was translated using a translation tool; please let me know if you spot any errors.
 
-This page is intended to help you quickly identify common setup, connection, and task issues. If you notice anything inaccurate or unclear, corrections are welcome.
+## operational issues
+### cannot start
+1.A pop-up window displays the message: `To run this application, you must install .NET`.
+1-1.Go and download [.NET 10.0 ](https://dotnet.microsoft.com/zh-tw/download/dotnet/thank-you/sdk-10.0.300-windows-x64-installer) and install ` .NET 10.0 Desktop Runtime` .
 
-## Running Issues
-
-### Cannot Start
-
-#### A popup says `To run this application, you must install .NET`
-
-- Download and install the [.NET 10.0 Desktop Runtime](https://dotnet.microsoft.com/zh-cn/download/dotnet/10.0).
-
-### Unable to Connect to the Game Window
-
-1. Make sure Neverness to Everness is already open.
+### Unable to Connect to Window
+1. Make sure you have opened Neverness to Everness(NTE).
 2. Make sure you are running MaaNTE as an administrator.
-3. Set the game to `1280x720` resolution and windowed mode.
+3. Set NTE to a resolution of `1280x720` and run it in windowed mode.
 
+:8870/home
 ## Task Issues
-
 ### General
+1. I have fewer features than others
+1-1. Some features only appear when a specific controller is selected; try switching controllers.
+1-2. The controller switching feature on the home page is currently malfunctioning; please change it in `Settings > Connection Settings`. The foreground controller is the mouse `Seize`, and the background controller is the mouse `SendMessageWithWindowPos`.
 
-#### I have fewer features than others
+2. Task completes immediately upon launch
+2-1. Check if the corresponding task is checked in the `Task List` on the left.
+2-2. Disable in-game features that affect image quality, such as frame interpolation and super-resolution.
 
-- Some features only appear after selecting a specific controller, so try switching controllers.
-- The controller switching option on the home page is currently unreliable. Please change it in `Settings > Connection Settings`. The foreground controller is mouse `Seize`, and the background controller is mouse `SendMessageWithWindowPos`.
+3. Unable to connect to a window or start a task
+3-1. Ensure you have added MaaNTE to your antivirus software’s whitelist, or temporarily disable your antivirus software.
+3-2. Ensure the game language is set to Simplified Chinese.
 
-#### A task finishes immediately after launch
+4. Unable to click or perform operations normally
+4-1. Ensure your MaaNTE is located in a path consisting solely of English characters and contains no full-width characters (it’s best to avoid any special characters as well).
+4-2. Ensure you are running MaaNTE as an administrator.
+4-3. If you cannot click normally, try changing the mouse input mode to `Seize`.
+4-4. Ensure Windows screen scaling is set to 100%.
 
-- Check whether the corresponding task is enabled in the `Task List` on the left.
-- Disable in-game features that affect image quality, such as frame interpolation and super-resolution.
+5. Mouse Seizure Issues
+5-1. In `Settings > Connection Settings`, change the mouse mode to `SendMessageWithWindowPos`. However, some tasks that require a foreground controller need `Seize` (which will seize the mouse).
 
-#### Unable to connect to a window or start a task
+6. Recognition Failure
+6-1. Disable in-game features that affect image quality, such as frame interpolation and super resolution.
 
-- Make sure MaaNTE is added to your antivirus whitelist, or temporarily disable your antivirus software.
-- Make sure the game language is set to Simplified Chinese.
-
-#### Unable to click or perform operations normally
-
-- Make sure MaaNTE is installed in a path that contains only English characters and no full-width characters. It is best to avoid special characters too.
-- Make sure you are running MaaNTE as an administrator.
-- If clicks do not work properly, try changing the mouse input mode to `Seize`.
-- Make sure Windows display scaling is set to 100%.
-
-#### Mouse capture issues
-
-- In `Settings > Connection Settings`, change the mouse mode to `SendMessageWithWindowPos`. However, some tasks that require a foreground controller still need `Seize`, which will capture the mouse.
-
-#### Recognition failure
-
-- Disable in-game features that affect image quality, such as frame interpolation and super-resolution.
 
 ## Additional Issues
-
 ### Auto-Fishing
+1. Unable to start fishing
+1-1. Refer to the section above: `Task Issues - General - Unable to connect to a window or start a task`
 
-#### Cannot start fishing
+2. Rod does not cast automatically
+2-1. Refer to the section above: `Task Issues - General - Unable to click or perform operations normally`
 
-- See [Task Issues - General - Unable to connect to a window or start a task](#unable-to-connect-to-a-window-or-start-a-task)
+3. Fish is not reeled in using the A/D keys
+3-1. Refer to the section above: `Task Issues - General - Unable to click or perform operations normally`
 
-#### The rod does not cast automatically
+4. Unable to sell catch
+4-1. Try setting the game to 120 FPS.
+4-2. The beta version is currently testing a new solution; please stay tuned.
 
-- See [Task Issues - General - Unable to click or perform operations normally](#unable-to-click-or-perform-operations-normally)
+5. Unable to purchase bait
+5-1. Lower the `Bait Detection Threshold`.
 
-#### The fish is not reeled in with the A/D keys
+6. Cannot catch fish
+6-1. The beta version is currently testing a new solution; please stay tuned.
 
-- See [Task Issues - General - Unable to click or perform operations normally](#unable-to-click-or-perform-operations-normally)
+7. Fishing quests end prematurely
+7-1. Ensure you have enough bait left for each round of fishing.
 
-#### Unable to sell catch
-
-- Try setting the game to 120 FPS.
-- The beta version is currently testing a new solution; please stay tuned.
-
-#### Unable to purchase bait
-
-- Lower the `Bait Detection Threshold`.
-
-#### Cannot catch fish
-
-- The beta version is currently testing a new solution; please stay tuned.
-
-#### Fishing quests end prematurely
-
-- Make sure you still have enough bait for each round of fishing.
 
 ### Real-time Assistant
+1. Window keeps moving around
+1-1. You must use the foreground controller (go to `Settings > Connection Settings` and set the mouse to `Seize`).
 
-#### The window keeps moving around
+2. Auto-Story cannot skip “Important Story” prompts
+2-1. We are planning to add this feature; please stay tuned.
 
-- You must use the foreground controller. Go to `Settings > Connection Settings` and set the mouse to `Seize`.
-
-#### Auto-Story cannot skip “Important Story” prompts
-
-- We are planning to add this feature; please stay tuned.
 
 ### Auto-Coffee
+1. Essentially, this automatically attacks everyone.
 
-#### Essentially, this automatically attacks everyone
-
-#### No rewards / No full combos
-
-- Requires Nanari and Shirakura’s City Skills.
+2. No rewards / No full combos
+2-1. Requires Nanari and Shirakura’s City Skills.

--- a/docs/eng/trouble_shooting.md
+++ b/docs/eng/trouble_shooting.md
@@ -1,79 +1,102 @@
-# MaaNTE Problem Troubleshooting Guide
-This text was translated using a translation tool; please let me know if you spot any errors.
+# MaaNTE Troubleshooting Guide
 
-## operational issues
-### cannot start
-1.A pop-up window displays the message: `To run this application, you must install .NET`.
-1-1.Go and download [.NET 10.0 ](https://dotnet.microsoft.com/zh-tw/download/dotnet/thank-you/sdk-10.0.300-windows-x64-installer) and install ` .NET 10.0 Desktop Runtime` .
+This page is intended to help you quickly identify common setup, connection, and task issues. If you notice anything inaccurate or unclear, corrections are welcome.
 
-### Unable to Connect to Window
-1. Make sure you have opened Neverness to Everness(NTE).
+## Running Issues
+
+### Cannot Start
+
+#### A popup says `To run this application, you must install .NET`
+
+- Download and install the [.NET 10.0 Desktop Runtime](https://dotnet.microsoft.com/zh-cn/download/dotnet/10.0).
+
+### Unable to Connect to the Game Window
+
+1. Make sure Neverness to Everness is already open.
 2. Make sure you are running MaaNTE as an administrator.
-3. Set NTE to a resolution of `1280x720` and run it in windowed mode.
+3. Set the game to `1280x720` resolution and windowed mode.
 
-:8870/home
 ## Task Issues
+
 ### General
-1. I have fewer features than others
-1-1. Some features only appear when a specific controller is selected; try switching controllers.
-1-2. The controller switching feature on the home page is currently malfunctioning; please change it in `Settings > Connection Settings`. The foreground controller is the mouse `Seize`, and the background controller is the mouse `SendMessageWithWindowPos`.
 
-2. Task completes immediately upon launch
-2-1. Check if the corresponding task is checked in the `Task List` on the left.
-2-2. Disable in-game features that affect image quality, such as frame interpolation and super-resolution.
+#### I have fewer features than others
 
-3. Unable to connect to a window or start a task
-3-1. Ensure you have added MaaNTE to your antivirus software’s whitelist, or temporarily disable your antivirus software.
-3-2. Ensure the game language is set to Simplified Chinese.
+- Some features only appear after selecting a specific controller, so try switching controllers.
+- The controller switching option on the home page is currently unreliable. Please change it in `Settings > Connection Settings`. The foreground controller is mouse `Seize`, and the background controller is mouse `SendMessageWithWindowPos`.
 
-4. Unable to click or perform operations normally
-4-1. Ensure your MaaNTE is located in a path consisting solely of English characters and contains no full-width characters (it’s best to avoid any special characters as well).
-4-2. Ensure you are running MaaNTE as an administrator.
-4-3. If you cannot click normally, try changing the mouse input mode to `Seize`.
-4-4. Ensure Windows screen scaling is set to 100%.
+#### A task finishes immediately after launch
 
-5. Mouse Seizure Issues
-5-1. In `Settings > Connection Settings`, change the mouse mode to `SendMessageWithWindowPos`. However, some tasks that require a foreground controller need `Seize` (which will seize the mouse).
+- Check whether the corresponding task is enabled in the `Task List` on the left.
+- Disable in-game features that affect image quality, such as frame interpolation and super-resolution.
 
-6. Recognition Failure
-6-1. Disable in-game features that affect image quality, such as frame interpolation and super resolution.
+#### Unable to connect to a window or start a task
 
+- Make sure MaaNTE is added to your antivirus whitelist, or temporarily disable your antivirus software.
+- Make sure the game language is set to Simplified Chinese.
+
+#### Unable to click or perform operations normally
+
+- Make sure MaaNTE is installed in a path that contains only English characters and no full-width characters. It is best to avoid special characters too.
+- Make sure you are running MaaNTE as an administrator.
+- If clicks do not work properly, try changing the mouse input mode to `Seize`.
+- Make sure Windows display scaling is set to 100%.
+
+#### Mouse capture issues
+
+- In `Settings > Connection Settings`, change the mouse mode to `SendMessageWithWindowPos`. However, some tasks that require a foreground controller still need `Seize`, which will capture the mouse.
+
+#### Recognition failure
+
+- Disable in-game features that affect image quality, such as frame interpolation and super-resolution.
 
 ## Additional Issues
+
 ### Auto-Fishing
-1. Unable to start fishing
-1-1. Refer to the section above: `Task Issues - General - Unable to connect to a window or start a task`
 
-2. Rod does not cast automatically
-2-1. Refer to the section above: `Task Issues - General - Unable to click or perform operations normally`
+#### Cannot start fishing
 
-3. Fish is not reeled in using the A/D keys
-3-1. Refer to the section above: `Task Issues - General - Unable to click or perform operations normally`
+- See [Task Issues - General - Unable to connect to a window or start a task](#unable-to-connect-to-a-window-or-start-a-task)
 
-4. Unable to sell catch
-4-1. Try setting the game to 120 FPS.
-4-2. The beta version is currently testing a new solution; please stay tuned.
+#### The rod does not cast automatically
 
-5. Unable to purchase bait
-5-1. Lower the `Bait Detection Threshold`.
+- See [Task Issues - General - Unable to click or perform operations normally](#unable-to-click-or-perform-operations-normally)
 
-6. Cannot catch fish
-6-1. The beta version is currently testing a new solution; please stay tuned.
+#### The fish is not reeled in with the A/D keys
 
-7. Fishing quests end prematurely
-7-1. Ensure you have enough bait left for each round of fishing.
+- See [Task Issues - General - Unable to click or perform operations normally](#unable-to-click-or-perform-operations-normally)
 
+#### Unable to sell catch
+
+- Try setting the game to 120 FPS.
+- The beta version is currently testing a new solution; please stay tuned.
+
+#### Unable to purchase bait
+
+- Lower the `Bait Detection Threshold`.
+
+#### Cannot catch fish
+
+- The beta version is currently testing a new solution; please stay tuned.
+
+#### Fishing quests end prematurely
+
+- Make sure you still have enough bait for each round of fishing.
 
 ### Real-time Assistant
-1. Window keeps moving around
-1-1. You must use the foreground controller (go to `Settings > Connection Settings` and set the mouse to `Seize`).
 
-2. Auto-Story cannot skip “Important Story” prompts
-2-1. We are planning to add this feature; please stay tuned.
+#### The window keeps moving around
 
+- You must use the foreground controller. Go to `Settings > Connection Settings` and set the mouse to `Seize`.
+
+#### Auto-Story cannot skip “Important Story” prompts
+
+- We are planning to add this feature; please stay tuned.
 
 ### Auto-Coffee
-1. Essentially, this automatically attacks everyone.
 
-2. No rewards / No full combos
-2-1. Requires Nanari and Shirakura’s City Skills.
+#### Essentially, this automatically attacks everyone
+
+#### No rewards / No full combos
+
+- Requires Nanari and Shirakura’s City Skills.

--- a/docs/jp/README_jp.md
+++ b/docs/jp/README_jp.md
@@ -43,9 +43,13 @@
 >
 > 本プロジェクトはまだ初期開発段階にあり、PR や Issue の提出を歓迎します。
 >
-> ダウンロード、ドキュメント、トラブルシューティングは **[公式サイト docs.maante.org](https://docs.maante.org/ja_jp/)** をご利用ください。QQ グループへの参加は [公式 QQ グループページ](https://docs.maante.org/zh_cn/qq-group/) から — 空きがあるグループが自動的に割り当てられます。
+> ダウンロード、ドキュメント、トラブルシューティングは **[公式サイト docs.maante.org](https://docs.maante.org/)** をご利用ください。
+> QQ グループへの参加は [公式 QQ グループページ](https://docs.maante.org/zh_cn/qq-group/) から — 空きがあるグループが自動的に割り当てられます。
 >
-> その他：[Bilibili @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
+> その他のチャンネル：
+> 公式 B 站アカウント: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
+>
+> 公式Discord: [Discord](https://discord.gg/e6mPMRYQpR)
 
 ### ⚠️免責事項とリスク警告
 

--- a/docs/jp/README_jp.md
+++ b/docs/jp/README_jp.md
@@ -7,7 +7,9 @@
   <p align="center">
     MAA異環小助手
     <br/>
-    <a href="/docs/eng/README_en.md">English</a> | <a href="/README.md">简体中文</a> | <a href="/docs/README_zh-tw.md">繁體中文</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">报告 Bug</a>
+    <a href="https://docs.maante.org/ja_jp/"><strong>公式サイト</strong></a>
+    ·
+    <a href="/docs/eng/README_en.md">English</a> | <a href="/README.md">简体中文</a> | <a href="/docs/README_zh-tw.md">繁體中文</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">バグ報告</a>
   </p>
 
   <p align="center">
@@ -15,6 +17,7 @@
     <img src="https://img.shields.io/badge/Language-Python%20%2F%20PipeLine-blue?style=flat-square&logo=Python" alt="Language" />
     <img alt="license" src="https://img.shields.io/github/license/1bananachicken/MaaNTE?style=flat-square">
     <br>
+    <a href="https://docs.maante.org/ja_jp/" target="_blank"><img alt="website" src="https://img.shields.io/badge/Website-docs.maante.org-00A98F?style=flat-square"></a>
     <a href="https://maafw.com/" target="_blank"><img alt="website" src="https://raw.githubusercontent.com/MaaXYZ/MaaFramework/refs/heads/main/docs/static/maafw.svg"></a>
     <a href="https://mirrorchyan.com/zh/projects?rid=MaaNTE" target="_blank"><img alt="mirrorc" src="https://raw.githubusercontent.com/MaaXYZ/MaaFramework/refs/heads/main/docs/static/mirrorc-zh.svg"></a>
     <a href="https://space.bilibili.com/3546893080594665" target="_blank"><img alt="Bilibili" src="https://img.shields.io/badge/Bilibili-MaaNTE--Official-00A1D6?logo=bilibili"></a>
@@ -28,89 +31,93 @@
 
 </div>
 
+> [!Warning]
+>
+> このドキュメントは AI 翻訳を使用しており、不正確な箇所がある可能性があります。修正の提案を歓迎します。
+
 > [!Caution]
 >
-> 最近、多くのアカウントがこのソフトウェアを二次配布し、さらには公式アカウントを偽装する事例が発生しています。 非公式な手段で入手したソフトウェアには**ウイルスが含まれている可能性**があり、一般的に最新のバージョンではありませんので、注意して見分けてください。
->
->最近、私たちはこのプロジェクトの名を借りてウイルスを広める行為があることを発見しました。ダウンロードする際は公式のチャネルを確認してください。
+> 最近、多くのアカウントがこのソフトウェアを二次配布したり、公式アカウントを装ったりする事例が発生しています。非公式な手段で入手したソフトウェアには**ウイルスが含まれている可能性**があり、通常は最新版ではありません。[GitHub Releases](https://github.com/1bananachicken/MaaNTE/releases) などの公式チャネルからダウンロードしてください。
 
 > [!Tip]
 >
-> 本プロジェクトはまだ初期開発段階にあり、PRやIssueの提出を歓迎します。
+> 本プロジェクトはまだ初期開発段階にあり、PR や Issue の提出を歓迎します。
+>
+> ダウンロード、ドキュメント、トラブルシューティングは **[公式サイト docs.maante.org](https://docs.maante.org/ja_jp/)** をご利用ください。QQ グループへの参加は [公式 QQ グループページ](https://docs.maante.org/zh_cn/qq-group/) から — 空きがあるグループが自動的に割り当てられます。
+>
+> その他：[Bilibili @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
-> [!Tip]
->
-> bili.com 公式: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)
->
-> QQ Group 1: 1103323319 (満員)
->
-> QQ Group 2: 1101147419 (満員)
->
-> QQ Group 3: 1075143235 (満員)
->
-> QQ Group 4: 713114598 (満員)
->
-> QQ Group 5: 1106448578
-
-# ⚠️免責事項とリスク警告
+## ⚠️免責事項とリスク警告
 
 > [!Note]
 >
-> 本ソフトウェアはサードパーティ製ツールであり、ゲーム画面を認識し、通常の操作をシミュレートすることで、『異環』のゲームプレイを簡素化するものです。本プロジェクトは関連する法律および規制を遵守しています。本プロジェクトはユーザーの反復作業を簡素化することを目的としており、ゲームのバランスを損なったり、不公平な優位性を提供したりすることはありません。また、ゲームファイルやデータを改変することもありません。
+> 本ソフトウェアはサードパーティ製ツールであり、ゲーム画面を認識し通常の操作をシミュレートすることで、『異環』のゲームプレイを簡素化するものです。本プロジェクトは関連する法律および規制を遵守しています。ユーザーの反復作業を簡素化することを目的としており、ゲームのバランスを損なったり不公平な優位性を提供したりすることはありません。また、ゲームファイルやデータを改変することもありません。
 >
-> 本プロジェクトはオープンソースかつ無料であり、学習および交流の目的でのみご利用ください。商業目的や営利目的での使用はご遠慮ください。開発チームは本プロジェクトに関する最終な解釈権をします。本ソフトウェアの使用に起因するいかなる問題についても、本プロジェクトおよび開発者は一切の責任を負いません。
+> 本プロジェクトはオープンソースかつ無料であり、学習および交流の目的でのみご利用ください。商業目的や営利目的での使用はご遠慮ください。開発チームは本プロジェクトに関する最終な解釈権を有します。本ソフトウェアの使用に起因するいかなる問題についても、本プロジェクトおよび開発者は一切の責任を負いません。
 
 > [!Caution]
 >
-> 根据[ゲーム運営の公平性に関するお知らせ](https://nte.perfectworld.com/jp/article/news/gamebroad/20260206/260831.html )：
+> [『異環』公平ゲーム宣言](https://nte.perfectworld.com/jp/article/news/gamebroad/20260206/260831.html) によると：
 >
-> 非公式ツールなど、ゲームの公平性を損なうツールの使用を固く禁止いたします。加速器やチートプログラム、マクロスクリプトなどの外部ツールの利用行為は厳しく取り締まり、違反が確認された場合は厳正に対処いたします。違反行為には、オートプレイ、スキルのスピードアップ、無敵化、瞬間移動、ゲーム内データの改ざんなどが含まれますが、これらに限られません。確認された場合、事実に基づきアカウント停止等の措置を取らせていただきます。
+> ゲームの公平性を損なう非公式ツールの使用は固く禁止されています。チート、スピードハック、マクロスクリプトなどの外部ツールの利用は厳しく取り締まり、違反が確認された場合はアカウント停止等の措置を取ります。違反行為には、オートプレイ、スキルのスピードアップ、無敵化、瞬間移動、ゲームデータの改ざんなどが含まれますが、これらに限られません。
 >
-> **あなたは、このツールを使用することによって生じる可能性のあるすべてのリスクを十分に理解し、自発的に引き受けるべきです。**
+> **本ツールの使用によって生じる可能性のあるすべてのリスクを十分に理解し、自発的に引き受けてください。**
 
 ## 🧾オープンソースライセンス
 
-このソフトウェアは [GNU Affero General Public License v3.0 only](https://spdx.org/licenses/AGPL-3.0-only.html) をオープンソースで使用します。
+本ソフトウェアは [GNU Affero General Public License v3.0 only](https://spdx.org/licenses/AGPL-3.0-only.html) の下でオープンソース化されています。
 
 ## ✨機能一覧
 
 - 🎣 自動釣り
-  - 🐟 自動釣り
+  - 🐟 自動で魚を売る
   - 🪝 自動で餌を買う
 - 🥤 自動でコーヒーを作る
   - 🔨 すべての顧客を追い出す
-- 💰 自動的にカフェの収益を抽出する
-  - 📦 自動補充貨物
-- 💎 自動で報酬を受け取る
-  - 🎁 アクティブ度
+- 💰 一咖舎の収益を自動受取
+  - 📦 自動補充
+  - 🏷️ 風向標に基づく商品の自動入れ替え
+- 🪑 家具の自動受取
+  - 🏠 ウィーナー/エデン/スカイビュー/金都/峰林の 5 つのアパートに対応
+- 💎 報酬の自動受取
+  - 🎁 アクティビティポイント
   - 📅 環期賞令
+- 🐾 ピンクパウ強盗
+  - 🔄 無限ループ放置対応
+  - 📊 収益統計とログ記録
+- 🧩 自動テトリス
+  - 🤖 内蔵 AI による自動判断
+  - 🔁 スタミナが尽きるまで自動連打
 - 🕛 リアルタイム支援
-  - 🗼 自動传送
-  - ⏩ 自動でストーリーをスキップ
+  - 🗼 自動テレポート
+  - ⏩ ストーリーの自動スキップ
+  - 🎁 自動拾得
 - ⚔️ 自動回避
   - 🛡️ 音声認識に基づく自動回避/反撃
-- 🎵 自動超強音
-  - 🥁 循環演奏迷星叫
-- 🎹 自動演奏ピアノ
-  - 📂 任意のMIDIインポートをサポート
+- 🎵 自動リズムゲーム
+  - 🥁 迷星叫のループ演奏
+- 🎹 自動ピアノ演奏
+  - 📂 任意の MIDI インポートに対応
+- 📋 プリセットタスク
+  - 💤 放置タスク / 🗺️ リアルタイム支援
 
 ## ❓よくある質問
 
-### 📄トラブルシューティングマニュアル
+### 📄トラブルシューティング
 
-まずは[トラブルシューティングマニュアル](../jp/トラブルシューティングマニュアル.md)に行って、解決策を探してください。
+まずは[トラブルシューティングマニュアル](../jp/トラブルシューティングマニュアル.md)をご確認ください。
 
-### 🤔どうやって起動するかわからない？
+### 🤔起動方法がわからない？
 
-- 普通のユーザーはリリース版をダウンロードしてください。開発の必要がある場合は、リポジトリをクローンしてください。
+- 一般ユーザーは [Release 版](https://github.com/1bananachicken/MaaNTE/releases) をダウンロードしてください。開発する場合のみリポジトリをクローンしてください。
 
-## 💡注目事項
+## 💡注意事項
 
-ゲームは1280x720の解像度でウィンドウモードで実行する必要があり、釣りの新しいアルゴリズムは120フレームでの実行をサポートしています。
+ゲームは 1280×720 解像度のウィンドウモードで実行する必要があります。釣りの新アルゴリズムは 120 FPS に対応しています。
 
 ## 💻開発ガイド
 
-開発に参加したい、またはプロジェクトを詳しく知りたい方はこちら 👉 [開発者ドキュメント](https://github.com/1bananachicken/MaaNTE/blob/dev/docs/zh_cn/develop/README.md)
+開発に参加したい、またはプロジェクトを詳しく知りたい方はこちら 👉 [開発者ドキュメント](../zh_cn/develop/README.md)
 
 コントリビューションをお待ちしています！一緒に MaaNTE をもっと強力にしましょう！💪
 
@@ -119,35 +126,36 @@
 ### オープンソースプロジェクト
 
 - [MaaFramework](https://github.com/MaaXYZ/MaaFramework)
-  基于图像识别的自动化黑盒测试框架
+  画像認識に基づく自動化ブラックボックステストフレームワーク
 - [MXU](https://github.com/MistEO/MXU)
   MaaFramework Next UI
 - [MaaAssistantArknights](https://github.com/MaaAssistantArknights/MaaAssistantArknights)
-  《明日方舟》小助手，全日常一键长草！
+  『アークナイツ』小助手 — デイリー作業をワンクリックで自動化！
 - [MaaEnd](https://github.com/MaaEnd/MaaEnd)
-  基于视觉 AI 的「明日方舟：终末地」自动化工具
+  視覚 AI ベースの『アークナイツ：エンドフィールド』自動化ツール
 - [M9A](https://github.com/MAA1999/M9A)
-  重返未来：1999 小助手
+  『リバース：1999』小助手
 - ~~[MFAAvalonia](https://github.com/SweetSmellFox/MFAAvalonia)
-  基于 Avalonia UI 构建的 MaaFramework 通用 GUI 解决方案~~
+  Avalonia UI で構築された MaaFramework 汎用 GUI ソリューション~~
 
-### 貢献者/参加者
+### 貢献者
 
-テストと開発に参加してくれたすべての開発者に感謝します(´▽`ʃ♡ƪ)
+テストと開発に参加してくれたすべての開発者に感謝します (´▽`ʃ♡ƪ)
 
 [![Contributors](https://contributors-img.web.app/image?repo=1bananachicken/MaaNTE&max=1000)](https://github.com/1bananachicken/MaaNTE/graphs/contributors)
 
-## ☕私たちにコーヒーをください。
+## ☕コーヒーをおごる
 
-もしMaaNTEがあなたの時間を大いに節約してくれたなら、開発者にコーヒーを奢ってあげてはいかがでしょうか？
+MaaNTE があなたの時間を節約してくれたなら、開発者にコーヒーをおごってみませんか？
 
-あなたのサポートが私たちの継続な更新の最大の原動力です🥰。
+あなたのサポートが、継続的な更新への最大の原動力です 🥰
 
-[<img width="200" alt="赞助我们" src="https://pic1.afdiancdn.com/static/img/welcome/button-sponsorme.png">](https://afdian.com/a/MaaNTE)
+[<img width="200" alt="スポンサー" src="https://pic1.afdiancdn.com/static/img/welcome/button-sponsorme.png">](https://afdian.com/a/MaaNTE)
 
 ## ⭐Star History
 
-もしこのソフトウェアがあなたに役立つと思ったら、ぜひスターを押してください！~（ウェブページの最上部右上角の小さな星）、これが私たちへの最大のサポートです！
+このソフトウェアが役に立ったと思ったら、ぜひ Star を押してください！（ページ右上の小さな星）— それが私たちへの最大のサポートです！
+
 <a href="https://www.star-history.com/?repos=1bananachicken%2FMaaNTE&type=date&legend=top-left">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=1bananachicken/MaaNTE&type=date&theme=dark&legend=top-left" />

--- a/docs/jp/README_jp.md
+++ b/docs/jp/README_jp.md
@@ -43,8 +43,8 @@
 >
 > 本プロジェクトはまだ初期開発段階にあり、PR や Issue の提出を歓迎します。
 >
-> ダウンロード、ドキュメント、トラブルシューティングは **[公式サイト docs.maante.org](https://docs.maante.org/)** をご利用ください。
-> QQ グループへの参加は [公式 QQ グループページ](https://docs.maante.org/zh_cn/qq-group/) から — 空きがあるグループが自動的に割り当てられます。
+> ダウンロード、ドキュメント、トラブルシューティングは **[公式サイト docs.maante.org](https://docs.maante.org/)** をご利用ください
+> QQ グループへの参加は [公式 QQ グループページ](https://docs.maante.org/zh_cn/qq-group/) から — 空きがあるグループが自動的に割り当てられます
 >
 > その他のチャンネル：
 > 公式 B 站アカウント: [MaaNTE-Official](https://space.bilibili.com/3546893080594665)

--- a/docs/jp/README_jp.md
+++ b/docs/jp/README_jp.md
@@ -7,9 +7,9 @@
   <p align="center">
     MAA異環小助手
     <br/>
-    <a href="https://docs.maante.org/ja_jp/"><strong>公式サイト</strong></a>
+    <a href="https://docs.maante.org/"><strong>公式サイト</strong></a>
     ·
-    <a href="/docs/eng/README_en.md">English</a> | <a href="/README.md">简体中文</a> | <a href="/docs/README_zh-tw.md">繁體中文</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">バグ報告</a>
+    <a href="../eng/README_en.md">English</a> | <a href="../README.md">简体中文</a> | <a href="../README_zh-tw.md">繁體中文</a> | <a href="https://github.com/1bananachicken/MaaNTE/issues">バグ報告</a>
   </p>
 
   <p align="center">
@@ -47,7 +47,7 @@
 >
 > その他：[Bilibili @MaaNTE-Official](https://space.bilibili.com/3546893080594665) · [Discord](https://discord.gg/e6mPMRYQpR)
 
-## ⚠️免責事項とリスク警告
+### ⚠️免責事項とリスク警告
 
 > [!Note]
 >
@@ -63,7 +63,7 @@
 >
 > **本ツールの使用によって生じる可能性のあるすべてのリスクを十分に理解し、自発的に引き受けてください。**
 
-## 🧾オープンソースライセンス
+### 🧾オープンソースライセンス
 
 本ソフトウェアは [GNU Affero General Public License v3.0 only](https://spdx.org/licenses/AGPL-3.0-only.html) の下でオープンソース化されています。
 
@@ -111,11 +111,11 @@
 
 - 一般ユーザーは [Release 版](https://github.com/1bananachicken/MaaNTE/releases) をダウンロードしてください。開発する場合のみリポジトリをクローンしてください。
 
-## 💡注意事項
+### 💡注意事項
 
 ゲームは 1280×720 解像度のウィンドウモードで実行する必要があります。釣りの新アルゴリズムは 120 FPS に対応しています。
 
-## 💻開発ガイド
+### 💻開発ガイド
 
 開発に参加したい、またはプロジェクトを詳しく知りたい方はこちら 👉 [開発者ドキュメント](../zh_cn/develop/README.md)
 


### PR DESCRIPTION
## Summary
- 整理 README 结构：合并重复提示框，更新功能列表（自动拾取、当前可用预设任务等）。
- 提升官网入口可见性：顶部导航与 badge 行均指向 docs.maante.org。
- QQ 交流群改为官网负载均衡页，自动分配未满群号，移除手动维护的群号列表。
- 同步更新 en / zh-tw / jp 三份 README 翻译。

## Test plan
- [ ] 在 GitHub 上预览 README.md 及各语言版本渲染效果
- [ ] 确认 docs.maante.org 与 /zh_cn/qq-group/ 链接可正常打开
- [ ] 确认功能列表与当前 interface.json 中已启用任务一致

## Summary by Sourcery

在所有语言版本的 README 中更新并同步文档内容，以突出官方文档网站，简化社区入口，并反映当前功能集。

文档更新内容：
- 在所有语言版本的 README 中，将 `docs.maante.org` 作为主要的官方网站入口进行推广，包括导航链接和徽章链接。
- 更新社区与支持信息，通过官方 QQ 群页面引导加入 QQ 群，而不是使用硬编码的群号。
- 刷新并统一简体中文、繁体中文、英文和日文 README 中的功能列表、常见问题、备注和措辞，使其与当前能力和术语保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update and synchronize README documentation across all languages to highlight the official docs site, streamline community entry points, and reflect the current feature set.

Documentation:
- Promote docs.maante.org as the primary official website entry in all README language variants, including navigation and badge links.
- Update community and support information to route QQ group joins through the official QQ group page instead of hardcoded group IDs.
- Refresh and align feature lists, FAQs, notes, and wording across Simplified Chinese, Traditional Chinese, English, and Japanese READMEs to match current capabilities and terminology.

</details>