### PR TITLE
chore: 加入迅雷云盘链接，更新夸克网盘链接

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -65,7 +65,8 @@ footer = """
 ## 国内下载源
 
 * [已有 Mirror酱 CDK？前往 Mirror酱 高速下载](https://mirrorchyan.com/zh/projects?rid=MaaNTE)
-* [夸克网盘](https://pan.quark.cn/s/b690fe93838b?pwd=PtXy) 提取码: PtXy
+* [迅雷云盘](https://pan.xunlei.com/s/VOtxqaDh_27smle-2mzDrZywA1?pwd=jx7c) 提取码: jx7c
+* [夸克网盘](https://pan.quark.cn/s/4b70d06b913c?pwd=irqh) 提取码: irqh
 * [百度网盘](https://pan.baidu.com/s/11QMC-aYfjfq52yco_UAwfg?pwd=tkmu) 提取码: tkmu
 """
 


### PR DESCRIPTION
## Summary by Sourcery

文档：
- 记录新的迅雷云盘下载镜像，并更新发行版页脚中的夸克网盘链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document new Xunlei Cloud download mirror and update the Quark Netdisk link in the release footer.

</details>