### PR TITLE
fix：修复钓鱼偶发退出

### DIFF
--- a/agent/custom/action/AutoFish/auto_fish_withoutCV.py
+++ b/agent/custom/action/AutoFish/auto_fish_withoutCV.py
@@ -71,7 +71,7 @@ class AutoFishWithoutCV(CustomAction):
                 fish_on_gaming = context.run_recognition("FishSceneOnFishGame", image)
                 if fish_on_gaming and fish_on_gaming.hit:
                     Print(
-                        "钓鱼异常结束（可能是鱼溜走），继续钓鱼"
+                        context, "钓鱼异常结束（可能是鱼溜走），继续钓鱼"
                     )  # 通常不会执行这一步
                     return CustomAction.RunResult(success=True)
                 continue

--- a/agent/custom/action/AutoFish/auto_fish_withoutCV.py
+++ b/agent/custom/action/AutoFish/auto_fish_withoutCV.py
@@ -56,7 +56,9 @@ class AutoFishWithoutCV(CustomAction):
                 and cursor.box
                 is not None  # 这个是为了消除pylance的warning，实际运行时不应该有None的情况
             ):
-                # 绿条/光标未命中时检查是否已弹出结算画面
+                time.sleep(0.5)
+                image = context.tasker.controller.post_screencap().wait().get()
+
                 click_blank = context.run_recognition("SceneClickBlankToExit", image)
                 if click_blank and click_blank.hit:
                     PrintT(context, "autofish.fish_caught")

--- a/agent/custom/action/AutoFish/auto_fish_withoutCV.py
+++ b/agent/custom/action/AutoFish/auto_fish_withoutCV.py
@@ -116,5 +116,5 @@ class AutoFishWithoutCV(CustomAction):
                     },
                 )
 
-        logger.debug("任务结束（success=True）")
+        logger.debug("任务中止")
         return CustomAction.RunResult(success=True)

--- a/agent/custom/action/AutoFish/auto_fish_withoutCV.py
+++ b/agent/custom/action/AutoFish/auto_fish_withoutCV.py
@@ -20,7 +20,6 @@ class AutoFishWithoutCV(CustomAction):
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
         deadzone = 15  # 光标与绿条中心的距离在 deadzone（像素）以内时不操作，避免过度频繁地轻微调整导致的抖动
-        max_try_item = 5  # 识别不完整（绿条或光标未命中）的最大尝试次数，超过后放弃本次钓鱼，重新抛竿（执行 FishHook）
         factor = 1.5  # 控条时长的调整因子，实际时长 = 基础时长 * factor，基础时长 = (光标与绿条中心的像素偏移 / CURSOR_PX_PER_SEC) * 1000ms，增加 factor 可以适当补偿识别误差和按键响应延迟
         cap_ms = (
             1500  # 控条时长的上限（毫秒），避免因识别到较大偏移时按键过久，导致过度补偿
@@ -32,7 +31,6 @@ class AutoFishWithoutCV(CustomAction):
             try:
                 params = json.loads(argv.custom_action_param)
                 deadzone = params.get("deadzone", deadzone)
-                max_try_item = params.get("max_try", max_try_item)
                 factor = params.get("factor", factor)
                 cap_ms = params.get("cap_ms", cap_ms)
                 floor_ms = params.get("floor_ms", floor_ms)
@@ -48,7 +46,7 @@ class AutoFishWithoutCV(CustomAction):
             green_bar = context.run_recognition("FishGreenBar", image)
             cursor = context.run_recognition("FishCursor", image)
 
-            if not (
+            while not (
                 green_bar
                 and green_bar.hit
                 and green_bar.box
@@ -62,17 +60,20 @@ class AutoFishWithoutCV(CustomAction):
                 click_blank = context.run_recognition("SceneClickBlankToExit", image)
                 if click_blank and click_blank.hit:
                     PrintT(context, "autofish.fish_caught")
+                    logger.debug("识别到钓上鱼, 钓鱼退出")
                     return CustomAction.RunResult(success=True)
 
-                max_try_item -= 1
-                logger.debug(
-                    f"识别不完整（绿条或光标未命中），剩余尝试次数: {max_try_item}"
-                )
-
-                if max_try_item <= 0:
-                    logger.debug("尝试次数用尽，控条失败")
+                fish_escape = context.run_recognition("FishEscape", image)
+                if fish_escape and fish_escape.hit:
+                    PrintT(context, "autofish.fish_escape")
+                    logger.debug("识别到鱼溜走，钓鱼退出")
                     return CustomAction.RunResult(success=True)
-                # 看来就是通过识别失败几次直接通用适配成功/失败的情况的，不用管，根本没有去识别有没有钓到
+                fish_on_gaming = context.run_recognition("FishSceneOnFishGame", image)
+                if fish_on_gaming and fish_on_gaming.hit:
+                    Print(
+                        "钓鱼异常结束（可能是鱼溜走），继续钓鱼"
+                    )  # 通常不会执行这一步
+                    return CustomAction.RunResult(success=True)
                 continue
 
             green_bar_x, green_bar_y, green_bar_w, green_bar_h = green_bar.box

--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -76,10 +76,6 @@
             "factor": 1.4
         },
         "pre_delay": 0,
-        "post_wait_freezes": {
-            "time": 1000,
-            "timeout": 6000
-        },
         "next": [
             "[Anchor]FishNewRestart",
             "[JumpBack]SceneClickBlankToExit"

--- a/assets/resource/base/pipeline/Fish/FishStatus.json
+++ b/assets/resource/base/pipeline/Fish/FishStatus.json
@@ -57,6 +57,17 @@
             }
         }
     },
+    "FishEscape": {
+        "desc": "鱼逃走",
+        "recognition": "OCR",
+        "expected": [
+            "鱼儿溜走了",
+            "The fish got away!"
+        ],
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
+    },
     "FishTest": {
         "post_delay": 0,
         "pre_delay": 0,

--- a/assets/resource/locales/agent/en_us.json
+++ b/assets/resource/locales/agent/en_us.json
@@ -1,5 +1,6 @@
 {
     "autofish.fish_caught": "Fish hooked!",
+    "autofish.fish_escape": "Fish escaped!",
     "autofish.task_end": "Fishing task ended",
     "autofish.started": "=== Auto Fishing Started ===",
     "autofish.progress": "=== Fishing %d/%d ===",

--- a/assets/resource/locales/agent/ja_jp.json
+++ b/assets/resource/locales/agent/ja_jp.json
@@ -1,5 +1,6 @@
 {
     "autofish.fish_caught": "魚がかかりました！",
+    "autofish.fish_escape": "魚が逃げました！",
     "autofish.task_end": "釣りタスク終了",
     "autofish.started": "=== 自動釣り開始 ===",
     "autofish.progress": "=== 釣り %d/%d ===",

--- a/assets/resource/locales/agent/ko_kr.json
+++ b/assets/resource/locales/agent/ko_kr.json
@@ -1,5 +1,6 @@
 {
     "autofish.fish_caught": "물고기가 걸렸습니다!",
+    "autofish.fish_escape": "물고기가 도망갔습니다!",
     "autofish.task_end": "낚시 작업 종료",
     "autofish.started": "=== 자동 낚시 시작 ===",
     "autofish.progress": "=== 낚시 %d/%d ===",

--- a/assets/resource/locales/agent/zh_cn.json
+++ b/assets/resource/locales/agent/zh_cn.json
@@ -1,5 +1,6 @@
 {
     "autofish.fish_caught": "钓上鱼了！",
+    "autofish.fish_escape": "鱼逃走了！",
     "autofish.task_end": "钓鱼任务结束",
     "autofish.started": "=== 自动钓鱼已启动 ===",
     "autofish.progress": "=== 钓鱼 %d/%d ===",

--- a/assets/resource/locales/agent/zh_tw.json
+++ b/assets/resource/locales/agent/zh_tw.json
@@ -1,5 +1,6 @@
 {
     "autofish.fish_caught": "釣上魚了！",
+    "autofish.fish_escape": "魚逃走了！",
     "autofish.task_end": "釣魚任務結束",
     "autofish.started": "=== 自動釣魚已啟動 ===",
     "autofish.progress": "=== 釣魚 %d/%d ===",


### PR DESCRIPTION
## Summary by Sourcery

改进钓鱼小游戏的自动化逻辑，能够正确检测和处理钓鱼结束状态，而不是在识别偶发失败时过早退出。

Bug Fixes:
- 通过在识别未完成时反复检查“鱼已钓上”、“鱼已逃走”或“异常结束”等状态，防止自动钓鱼偶尔提前退出。

Enhancements:
- 移除钓鱼控制逻辑中基于重试计数器的回退机制，改为依赖明确的场景/状态识别来结束一次钓鱼尝试。
- 扩展钓鱼状态的配置和本地化条目，以覆盖新的钓鱼结果消息和状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the fishing minigame automation to correctly detect and handle end-of-fishing states instead of exiting early on intermittent recognition failures.

Bug Fixes:
- Prevent occasional premature exit from auto-fishing by repeatedly checking for fish caught, fish escaped, or abnormal end states while recognition is incomplete.

Enhancements:
- Remove the retry-counter based fallback in fishing control logic and rely on explicit scene/status recognition for ending a fishing attempt.
- Extend fishing status configuration and localization entries to cover new fishing outcome messages and states.

</details>