### PR TITLE
Fix: 优化日志体系，避免重复落盘，缓解日志文件过大的问题

### DIFF
--- a/agent/custom/action/Common/logger.py
+++ b/agent/custom/action/Common/logger.py
@@ -1,30 +1,7 @@
 import logging
-import os
-from pathlib import Path
+
+from utils.logger import get_logger as _get_shared_logger
 
 
 def get_logger(name: str) -> logging.Logger:
-    logger = logging.getLogger(name)
-    if logger.handlers:
-        return logger
-
-    logger.setLevel(logging.DEBUG)
-
-    log_dir = Path("./debug")
-    log_dir.mkdir(parents=True, exist_ok=True)
-    fh = logging.FileHandler(log_dir / "agent.log", encoding="utf-8")
-    fh.setLevel(logging.DEBUG)
-
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-
-    fmt = logging.Formatter(
-        "[%(asctime)s][%(name)s][%(levelname)s] %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    fh.setFormatter(fmt)
-    ch.setFormatter(fmt)
-
-    logger.addHandler(fh)
-    logger.addHandler(ch)
-    return logger
+    return _get_shared_logger(name)

--- a/agent/utils/logger.py
+++ b/agent/utils/logger.py
@@ -138,13 +138,24 @@ class _ConsoleFormatter(logging.Formatter):
 _FILE_FORMAT = logging.Formatter(
     "%(asctime)s | %(levelname)-8s | %(name)s:%(funcName)s:%(lineno)d | %(message)s"
 )
-_std_logger = logging.getLogger("maante")
+_APP_LOGGER_NAME = "maante"
+_ROOT_LOGGER = logging.getLogger()
+_NOISY_LOGGER_NAMES = ("cv2", "numpy", "PIL", "matplotlib", "urllib3", "asyncio")
 
 
 def _resolve_level(level) -> int:
     if isinstance(level, int):
         return level
     return getattr(logging, str(level).upper(), logging.INFO)
+
+
+def _configure_noisy_loggers():
+    for name in _NOISY_LOGGER_NAMES:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def get_logger(name=None):
+    return logging.getLogger(name or _APP_LOGGER_NAME)
 
 
 def _setup_loguru_logger(log_dir="debug/custom", console_level="INFO"):
@@ -172,25 +183,26 @@ def _setup_loguru_logger(log_dir="debug/custom", console_level="INFO"):
         filter=_enrich_record,
     )
 
-    logging.root.handlers = [_InterceptHandler()]
-    logging.root.setLevel(logging.DEBUG)
-    for name in ("cv2", "numpy", "PIL", "matplotlib", "urllib3", "asyncio"):
-        logging.getLogger(name).setLevel(logging.WARNING)
+    _ROOT_LOGGER.handlers = [_InterceptHandler()]
+    _ROOT_LOGGER.setLevel(logging.DEBUG)
+    _configure_noisy_loggers()
 
-    return _loguru_logger
+    app_logger = get_logger(_APP_LOGGER_NAME)
+    app_logger.setLevel(logging.NOTSET)
+    app_logger.propagate = True
+    return app_logger
 
 
 def _setup_std_logger(log_dir="debug/custom", console_level="INFO"):
     os.makedirs(log_dir, exist_ok=True)
 
-    _std_logger.handlers.clear()
-    _std_logger.setLevel(logging.DEBUG)
-    _std_logger.propagate = False
+    _ROOT_LOGGER.handlers.clear()
+    _ROOT_LOGGER.setLevel(logging.DEBUG)
 
     console_handler = logging.StreamHandler(_resolve_console_stream())
     console_handler.setLevel(_resolve_level(console_level))
     console_handler.setFormatter(_ConsoleFormatter())
-    _std_logger.addHandler(console_handler)
+    _ROOT_LOGGER.addHandler(console_handler)
 
     file_handler = TimedRotatingFileHandler(
         os.path.join(log_dir, "runtime.log"),
@@ -201,13 +213,18 @@ def _setup_std_logger(log_dir="debug/custom", console_level="INFO"):
     )
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(_FILE_FORMAT)
-    _std_logger.addHandler(file_handler)
+    _ROOT_LOGGER.addHandler(file_handler)
 
-    return _std_logger
+    _configure_noisy_loggers()
+
+    app_logger = get_logger(_APP_LOGGER_NAME)
+    app_logger.setLevel(logging.NOTSET)
+    app_logger.propagate = True
+    return app_logger
 
 
 def setup_logger(log_dir="debug/custom", console_level="INFO"):
-    """设置 logger（优先 loguru，无 loguru 时回退到标准 logging）"""
+    """设置统一 logger（优先 loguru，无 loguru 时回退到标准 logging）"""
     if _HAS_LOGURU:
         return _setup_loguru_logger(log_dir=log_dir, console_level=console_level)
     return _setup_std_logger(log_dir=log_dir, console_level=console_level)
@@ -219,6 +236,7 @@ def change_console_level(level="DEBUG"):
     logger.info(f"控制台日志等级已更改为: {level}")
 
 
-logger = setup_logger(console_level="WARNING" if _is_mxu_client() else "INFO")
+setup_logger(console_level="WARNING" if _is_mxu_client() else "INFO")
+logger = get_logger(_APP_LOGGER_NAME)
 
-__all__ = ["setup_logger", "change_console_level", "logger"]
+__all__ = ["setup_logger", "change_console_level", "get_logger", "logger"]


### PR DESCRIPTION
原本日志体系有两条链路 ，`agent/custom/action/Common/logger.py` 中额外维护了一套独立日志输出，持续写入 `debug/agent.log` ，这可能造成同类日志重复记录且该链路没有轮转与保留策略，导致仅使用几天后 `debug` 文件夹大小持续增长至50GB
所以将 `custom action` 的独立日志并入统一日志体系，复用 `agent/utils/logger.py` 中已有的轮转与保留策略

## Summary by Sourcery

将自定义动作日志记录统一到共享的应用程序日志记录器中，以减少重复的日志写入，并利用现有的轮转/保留策略。

Enhancements:
- 通过共享的 `get_logger` 帮助函数集中获取日志记录器，并使用一致的应用程序日志记录器名称。
- 通过根日志记录器配置日志，包括对噪声较大的第三方库进行标准化的日志级别调整，同时为调用方返回一个应用程序特定的日志记录器。
- 用共享的日志基础设施替换自定义 action 模块中独立的文件/控制台日志记录器配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify custom action logging with the shared application logger to reduce duplicate log writes and leverage existing rotation/retention policies.

Enhancements:
- Centralize logger retrieval through a shared get_logger helper using a consistent application logger name.
- Configure logging via the root logger, including standardized noisy-library level adjustments, while returning an application-specific logger for use by callers.
- Replace the custom action module's standalone file/console logger setup with reuse of the shared logging infrastructure.

</details>