### PR TITLE
fix: 修复无历练奖赏可领时不会结束任务的问题

### DIFF
--- a/assets/resource/base/pipeline/ClaimRewards.json
+++ b/assets/resource/base/pipeline/ClaimRewards.json
@@ -100,7 +100,7 @@
         "action": "Click",
         "post_wait_freezes": 500,
         "next": [
-            "ClaimRewardsBattlePassExp",
+            "[JumpBack]ClaimRewardsBattlePassExp",
             "ClaimRewardsBattlePassBackToPage1"
         ]
     },
@@ -147,7 +147,8 @@
         "action": "Click",
         "post_wait_freezes": 500,
         "next": [
-            "ClaimRewardsBattlePassRewards"
+            "[JumpBack]ClaimRewardsBattlePassRewards",
+            "ClaimRewardsExit"
         ]
     },
     "ClaimRewardsBattlePassRewards": {
@@ -171,12 +172,12 @@
                 "threshold": 0.8
             }
         },
-        "action": "Click",
-        "next": [
-            "ClaimRewardsExit"
-        ]
+        "action": "Click"
     },
     "ClaimRewardsExit": {
-        "desc": "领取奖励任务出口"
+        "desc": "领取奖励任务出口",
+        "pre_delay": 0,
+        "post_delay": 0,
+        "rate_limit": 0
     }
 }


### PR DESCRIPTION
close #272

## Summary by Sourcery

错误修复：
- 修复在 ClaimRewards 流程中，当没有可领取的经验奖励时，任务流程无法正常结束的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix task flow not finishing when no experience rewards are available to claim in the ClaimRewards pipeline.

</details>