### PR TITLE
fix(FishNew): 在钓鱼的while循环中更新green_bar和cursor以避免误判

### DIFF
--- a/agent/custom/action/AutoFish/auto_fish_withoutCV.py
+++ b/agent/custom/action/AutoFish/auto_fish_withoutCV.py
@@ -58,7 +58,6 @@ class AutoFishWithoutCV(CustomAction):
             ):
                 time.sleep(0.5)
                 image = context.tasker.controller.post_screencap().wait().get()
-
                 click_blank = context.run_recognition("SceneClickBlankToExit", image)
                 if click_blank and click_blank.hit:
                     PrintT(context, "autofish.fish_caught")
@@ -76,7 +75,8 @@ class AutoFishWithoutCV(CustomAction):
                         context, "钓鱼异常结束（可能是鱼溜走），继续钓鱼"
                     )  # 通常不会执行这一步
                     return CustomAction.RunResult(success=True)
-                continue
+                green_bar = context.run_recognition("FishGreenBar", image)
+                cursor = context.run_recognition("FishCursor", image)
 
             green_bar_x, green_bar_y, green_bar_w, green_bar_h = green_bar.box
             cursor_x, cursor_y, cursor_w, cursor_h = cursor.box


### PR DESCRIPTION
close #281

## Summary by Sourcery

错误修复：
- 通过在每次循环迭代时重新运行绿色进度条和光标识别，修复自动钓鱼中可能的误检测问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix potential misdetection in autofishing by re-running green bar and cursor recognition on each loop iteration.

</details>