### PR TITLE
feat(resolution): 支持动态分辨率适配

### DIFF
--- a/agent/custom/action/AutoFish/auto_buy_fish_bait.py
+++ b/agent/custom/action/AutoFish/auto_buy_fish_bait.py
@@ -3,7 +3,7 @@ import time
 import json
 
 from pathlib import Path
-from ..Common.utils import get_image, match_template_in_region, click_rect
+from ..Common.utils import get_image, match_template_in_region_720, click_rect, click_rect_720
 from utils import screen
 
 from maa.agent.agent_server import AgentServer
@@ -38,26 +38,20 @@ class AutoBuyFishBait(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
+        controller = context.tasker.controller
+        get_image(controller)
+
         fish_shop_region = [35, 88, 410, 475]
         find_bait_success_region = [1044, 131, 68, 23]
         select_max_region = [1202, 620, 33, 32]
         buy_region = [1050, 674, 50, 25]
         buy_confirm_region = [749, 462, 47, 25]
         buy_success_region = [569, 629, 145, 19]
-        not_enough_shell_region = [1170, 585, 18, 16]
-        shell_count_region = [961, 31, 70, 21]
 
-        fish_shop_region = screen.map_rect(fish_shop_region)
-        find_bait_success_region = screen.map_rect(find_bait_success_region)
-        select_max_region = screen.map_rect(select_max_region)
-        buy_region = screen.map_rect(buy_region)
-        buy_confirm_region = screen.map_rect(buy_confirm_region)
-        buy_success_region = screen.map_rect(buy_success_region)
-        not_enough_shell_region = screen.map_rect(not_enough_shell_region)
-        shell_count_region = screen.map_rect(shell_count_region)
+        click_w, click_h = screen.map_point_to_frame(30, 10)
+
         KEY_R = 82
         KEY_ESC = 27
-        controller = context.tasker.controller
 
         found_bait_threshold = 0.7
         if argv.custom_action_param:
@@ -72,7 +66,7 @@ class AutoBuyFishBait(CustomAction):
         match_threshold = 0.7
         while True:
             img = get_image(controller)
-            found_bait, prob, x, y = match_template_in_region(
+            found_bait, prob, x, y = match_template_in_region_720(
                 img, fish_shop_region, self.bait_template, found_bait_threshold
             )
             if found_bait:
@@ -80,12 +74,12 @@ class AutoBuyFishBait(CustomAction):
                     x, y
                 )  # 先移动到指定位置再进行点击，否则可能会触发滑动买到别的东东
                 for _ in range(3):
-                    click_rect(controller, [x, y, 30, 10])
+                    click_rect(controller, [x, y, click_w, click_h])
                     time.sleep(0.1)
 
                 time.sleep(1)  # 120hz下可能会过快地出现触发检测。适当的延时
                 img = get_image(controller)
-                found_bait_success, _, _, _ = match_template_in_region(
+                found_bait_success, _, _, _ = match_template_in_region_720(
                     img,
                     find_bait_success_region,
                     self.find_bait_success_template,
@@ -105,13 +99,13 @@ class AutoBuyFishBait(CustomAction):
 
         while True:
             img = get_image(controller)
-            found_select_max, prob, _, _ = match_template_in_region(
+            found_select_max, prob, _, _ = match_template_in_region_720(
                 img, select_max_region, self.select_max_template, match_threshold
             )
             if found_select_max:
                 PrintT(context, "autofish.select_max_found")
                 for _ in range(5):
-                    click_rect(controller, select_max_region, 0.3)
+                    click_rect_720(controller, select_max_region, 0.3)
                     time.sleep(0.1)
                 time.sleep(1)
                 break
@@ -121,13 +115,13 @@ class AutoBuyFishBait(CustomAction):
 
         while True:
             img = get_image(controller)
-            found_buy, _, _, _ = match_template_in_region(
+            found_buy, _, _, _ = match_template_in_region_720(
                 img, buy_region, self.buy_template, match_threshold
             )
             if found_buy:
                 PrintT(context, "autofish.buy_button_click")
                 for _ in range(3):
-                    click_rect(controller, buy_region, 0.3)
+                    click_rect_720(controller, buy_region, 0.3)
                     time.sleep(0.1)
                 time.sleep(0.5)
                 break
@@ -137,13 +131,13 @@ class AutoBuyFishBait(CustomAction):
 
         for _ in range(5):
             img = get_image(controller)
-            found_buy_confirm, _, _, _ = match_template_in_region(
+            found_buy_confirm, _, _, _ = match_template_in_region_720(
                 img, buy_confirm_region, self.buy_confirm_template, match_threshold
             )
             if found_buy_confirm:
                 PrintT(context, "autofish.buy_confirm_click")
                 for _ in range(3):
-                    click_rect(controller, buy_confirm_region)
+                    click_rect_720(controller, buy_confirm_region)
                     time.sleep(0.1)
                 time.sleep(0.5)
                 break
@@ -153,7 +147,7 @@ class AutoBuyFishBait(CustomAction):
 
         while True:
             img = get_image(controller)
-            found_buy_success, _, _, _ = match_template_in_region(
+            found_buy_success, _, _, _ = match_template_in_region_720(
                 img, buy_success_region, self.buy_success_template, match_threshold
             )
             if found_buy_success:

--- a/agent/custom/action/AutoFish/auto_fish.py
+++ b/agent/custom/action/AutoFish/auto_fish.py
@@ -3,7 +3,7 @@ import time
 import json
 
 from pathlib import Path
-from ..Common.utils import get_image, match_template_in_region
+from ..Common.utils import get_image, match_template_in_region_720
 from ..Common.logger import get_logger
 from utils import screen
 
@@ -68,6 +68,7 @@ class AutoFish(CustomAction):
         KEY_F = 70
         KEY_ESC = 27
 
+        get_image(controller)
         success_region = [520, 160, 265, 30]
         settlement_region = [566, 642, 150, 23]
         game_region = [401, 39, 481, 24]
@@ -76,16 +77,10 @@ class AutoFish(CustomAction):
         fish_game_sign_region = [1141, 609, 87, 84]
         fish_game_sign_region_2 = [1224, 27, 30, 30]
         need_bait_region = [610, 350, 141, 21]
-        deadzone = max(1, int(round(15 * screen.scaling_factors()[0])))
+        deadzone_720 = 15
+        deadzone = max(1, int(round(deadzone_720 * screen.frame_scaling_factors()[0])))
 
-        success_region = screen.map_rect(success_region)
-        settlement_region = screen.map_rect(settlement_region)
-        game_region = screen.map_rect(game_region)
-        escape_region = screen.map_rect(escape_region)
-        prepare_region = screen.map_rect(prepare_region)
-        fish_game_sign_region = screen.map_rect(fish_game_sign_region)
-        fish_game_sign_region_2 = screen.map_rect(fish_game_sign_region_2)
-        need_bait_region = screen.map_rect(need_bait_region)
+        game_region_frame = screen.map_rect_to_frame(game_region)
 
         def press_esc():
             controller.post_key_down(KEY_ESC)
@@ -99,7 +94,7 @@ class AutoFish(CustomAction):
                     return False
 
                 img = get_image(controller)
-                matched, _, _, _ = match_template_in_region(
+                matched, _, _, _ = match_template_in_region_720(
                     img, settlement_region, self.settlement_template, 0.8
                 )
 
@@ -113,7 +108,7 @@ class AutoFish(CustomAction):
             for _ in range(10):
                 img = get_image(controller)
 
-                m_settle, _, _, _ = match_template_in_region(
+                m_settle, _, _, _ = match_template_in_region_720(
                     img, settlement_region, self.settlement_template, 0.8
                 )
                 if m_settle:
@@ -124,7 +119,7 @@ class AutoFish(CustomAction):
                     wait_until_settlement_disappears()
                     continue
 
-                m_game, game_prob, _, _ = match_template_in_region(
+                m_game, game_prob, _, _ = match_template_in_region_720(
                     img,
                     fish_game_sign_region_2,
                     self.fish_game_sign_template,
@@ -137,12 +132,13 @@ class AutoFish(CustomAction):
                 if m_game:
                     return True
 
-                m_prepare, _, x, y = match_template_in_region(
+                m_prepare, _, x, y = match_template_in_region_720(
                     img, prepare_region, self.prepare_start_template, 0.7
                 )
                 if m_prepare:
                     # logger.debug("On FishPrepare screen, pressing start...")
-                    controller.post_click(x + 15, y + 15)
+                    offset_x, offset_y = screen.map_point_to_frame(15, 15)
+                    controller.post_click(x + offset_x, y + offset_y)
                     time.sleep(1.5)
                     return True
 
@@ -169,7 +165,7 @@ class AutoFish(CustomAction):
 
                 for _ in range(5):
                     img = get_image(controller)
-                    m_need_bait, prob, _, _ = match_template_in_region(
+                    m_need_bait, prob, _, _ = match_template_in_region_720(
                         img, need_bait_region, self.need_bait_template, 0.7
                     )
                     # logger.debug(f"Checking for bait, probability: {prob:.2f}")
@@ -200,7 +196,7 @@ class AutoFish(CustomAction):
                     time.sleep(check_freq)
                     img = get_image(controller)
 
-                    m_settle_unexpected, _, _, _ = match_template_in_region(
+                    m_settle_unexpected, _, _, _ = match_template_in_region_720(
                         img, settlement_region, self.settlement_template, 0.8
                     )
                     if m_settle_unexpected:
@@ -209,7 +205,7 @@ class AutoFish(CustomAction):
                         # )
                         break
 
-                    m_catch, _, _, _ = match_template_in_region(
+                    m_catch, _, _, _ = match_template_in_region_720(
                         img, success_region, self.success_catch_template, 0.7
                     )
                     if m_catch:
@@ -224,10 +220,10 @@ class AutoFish(CustomAction):
 
                 start_time = time.time()
                 frame = 0
-                deadzone = 15
+                deadzone = max(1, int(round(deadzone_720 * screen.frame_scaling_factors()[0])))
                 current_ad_key = None
                 last_bar_width = 100
-                last_target = (game_region[0] + game_region[2]) / 2
+                last_target = (game_region_frame[0] + game_region_frame[2]) / 2
                 last_x_slider = last_target
                 slider_miss_count = 0
 
@@ -250,26 +246,26 @@ class AutoFish(CustomAction):
                     frame += 1
 
                     if frame % 10 == 0:
-                        m_settle, _, _, _ = match_template_in_region(
+                        m_settle, _, _, _ = match_template_in_region_720(
                             img, settlement_region, self.settlement_template, 0.8
                         )
                         if m_settle:
                             # logger.debug("Fish caught!")
                             break
-                        m_escape, _, _, _ = match_template_in_region(
+                        m_escape, _, _, _ = match_template_in_region_720(
                             img, escape_region, self.escape_template, 0.8
                         )
                         if m_escape:
                             # logger.debug("Fish escaped! Recasting...")
                             break
 
-                    m_left, _, x_left, _ = match_template_in_region(
+                    m_left, _, x_left, _ = match_template_in_region_720(
                         img, game_region, self.valid_region_left_template, 0.7
                     )
-                    m_right, _, x_right, _ = match_template_in_region(
+                    m_right, _, x_right, _ = match_template_in_region_720(
                         img, game_region, self.valid_region_right_template, 0.7
                     )
-                    m_slider, _, x_slider, _ = match_template_in_region(
+                    m_slider, _, x_slider, _ = match_template_in_region_720(
                         img, game_region, self.slider_template, 0.7
                     )
 
@@ -323,7 +319,7 @@ class AutoFish(CustomAction):
 
                 img = get_image(controller)
                 time.sleep(0.3)
-                m_escape, _, _, _ = match_template_in_region(
+                m_escape, _, _, _ = match_template_in_region_720(
                     img, escape_region, self.escape_template, 0.8
                 )
                 if m_escape:
@@ -339,7 +335,7 @@ class AutoFish(CustomAction):
                     return CustomAction.RunResult(success=False)
 
                 img = get_image(controller)
-                match_settle, settle_prob, _, _ = match_template_in_region(
+                match_settle, settle_prob, _, _ = match_template_in_region_720(
                     img, settlement_region, self.settlement_template, 0.8
                 )
                 # logger.debug(

--- a/agent/custom/action/AutoFish/auto_fish_withoutCV.py
+++ b/agent/custom/action/AutoFish/auto_fish_withoutCV.py
@@ -7,6 +7,7 @@ import json
 
 from utils.logger import logger
 from utils.maafocus import Print, PrintT
+from utils import screen
 
 # 长按左/右键时，光标在进度条上水平移动约 200 像素/秒，用于将偏移（像素）换算为 LongPress 时长
 CURSOR_PX_PER_SEC = (
@@ -37,12 +38,16 @@ class AutoFishWithoutCV(CustomAction):
             except Exception:
                 pass
 
+        deadzone_720 = deadzone
+
         logger.debug("钓鱼开始：进入控条阶段（绿条/光标对齐）")
         # 钓鱼阶段
         while not context.tasker.stopping:
             image = (
                 context.tasker.controller.post_screencap().wait().get()
-            )  # (720, 1280, 3)，自动缩放至框架规定的标准res
+            )
+            screen.update_frame_size_from_image(image)
+            deadzone = max(1, int(round(deadzone_720 * screen.frame_scaling_factors()[0])))
             green_bar = context.run_recognition("FishGreenBar", image)
             cursor = context.run_recognition("FishCursor", image)
 
@@ -58,6 +63,8 @@ class AutoFishWithoutCV(CustomAction):
             ):
                 time.sleep(0.5)
                 image = context.tasker.controller.post_screencap().wait().get()
+                screen.update_frame_size_from_image(image)
+                deadzone = max(1, int(round(deadzone_720 * screen.frame_scaling_factors()[0])))
                 click_blank = context.run_recognition("SceneClickBlankToExit", image)
                 if click_blank and click_blank.hit:
                     PrintT(context, "autofish.fish_caught")
@@ -88,7 +95,7 @@ class AutoFishWithoutCV(CustomAction):
             offset = cursor_center_x - green_bar_center_x
 
             abs_offset = abs(offset)
-            scaled_px_per_sec = max(1.0, CURSOR_PX_PER_SEC)
+            scaled_px_per_sec = max(1.0, CURSOR_PX_PER_SEC * screen.frame_scaling_factors()[0])
             base_ms = (abs_offset / scaled_px_per_sec) * 1000.0
             duration_ms = min(cap_ms, max(floor_ms, int(base_ms * factor)))
 

--- a/agent/custom/action/AutoFish/auto_sell_fish.py
+++ b/agent/custom/action/AutoFish/auto_sell_fish.py
@@ -2,8 +2,7 @@ import cv2
 import time
 
 from pathlib import Path
-from ..Common.utils import get_image, match_template_in_region, click_rect
-from utils import screen
+from ..Common.utils import get_image, match_template_in_region_720, click_rect_720
 
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
@@ -42,6 +41,7 @@ class AutoSellFish(CustomAction):
     ) -> CustomAction.RunResult:
         PrintT(context, "autofish.sell_started")
         controller = context.tasker.controller
+        get_image(controller)
 
         KEY_Q = 81
         KEY_ESC = 27
@@ -53,29 +53,19 @@ class AutoSellFish(CustomAction):
         confirm_sell_region = [756, 461, 48, 21]
         sell_success_region = [565, 628, 149, 21]
         sell_fail_region = [739, 349, 202, 24]
-        no_valid_fish_region = [509, 350, 261, 22]
-
-        no_fish_to_sell_region = screen.map_rect(no_fish_to_sell_region)
-        sell_option_region = screen.map_rect(sell_option_region)
-        sell_option_selected_region = screen.map_rect(sell_option_selected_region)
-        sell_button_region = screen.map_rect(sell_button_region)
-        confirm_sell_region = screen.map_rect(confirm_sell_region)
-        sell_success_region = screen.map_rect(sell_success_region)
-        sell_fail_region = screen.map_rect(sell_fail_region)
-        no_valid_fish_region = screen.map_rect(no_valid_fish_region)
 
         while True:
             img = get_image(controller)
-            found_sell_option, _, _, _ = match_template_in_region(
+            found_sell_option, _, _, _ = match_template_in_region_720(
                 img, sell_option_region, self.sell_option_template, 0.7
             )
             if found_sell_option:
                 for _ in range(3):
-                    click_rect(controller, sell_option_region)
+                    click_rect_720(controller, sell_option_region)
                     time.sleep(0.1)
 
                 img = get_image(controller)
-                found_sell_option_selected, _, _, _ = match_template_in_region(
+                found_sell_option_selected, _, _, _ = match_template_in_region_720(
                     img,
                     sell_option_selected_region,
                     self.sell_option_selected_template,
@@ -92,7 +82,7 @@ class AutoSellFish(CustomAction):
 
         for _ in range(5):
             img = get_image(controller)
-            found_no_fish_to_sell, prob, _, _ = match_template_in_region(
+            found_no_fish_to_sell, prob, _, _ = match_template_in_region_720(
                 img, no_fish_to_sell_region, self.no_fish_to_sell_template, 0.8
             )
             time.sleep(0.1)
@@ -105,24 +95,24 @@ class AutoSellFish(CustomAction):
 
         while True:
             img = get_image(controller)
-            found_sell_button, _, _, _ = match_template_in_region(
+            found_sell_button, _, _, _ = match_template_in_region_720(
                 img, sell_button_region, self.sell_button_template, 0.8
             )
             if found_sell_button:
                 PrintT(context, "autofish.sell_button_detected")
                 while True:
-                    click_rect(controller, sell_button_region, 0.1)
+                    click_rect_720(controller, sell_button_region, 0.1)
                     time.sleep(0.5)
                     img = get_image(controller)
-                    found_confirm_sell, _, _, _ = match_template_in_region(
+                    found_confirm_sell, _, _, _ = match_template_in_region_720(
                         img, confirm_sell_region, self.confirm_sell_template, 0.8
                     )
-                    sell_fail, _, _, _ = match_template_in_region(
+                    sell_fail, _, _, _ = match_template_in_region_720(
                         img, sell_fail_region, self.sell_fail_template, 0.8
                     )
                     if found_confirm_sell:
                         PrintT(context, "autofish.confirm_sell_detected")
-                        click_rect(controller, confirm_sell_region, 0.2)
+                        click_rect_720(controller, confirm_sell_region, 0.2)
                         time.sleep(0.5)
                         break
                     elif sell_fail:
@@ -137,7 +127,7 @@ class AutoSellFish(CustomAction):
 
         while True:
             img = get_image(controller)
-            found_sell_success, _, _, _ = match_template_in_region(
+            found_sell_success, _, _, _ = match_template_in_region_720(
                 img, sell_success_region, self.sell_success_template, 0.8
             )
             if found_sell_success:

--- a/agent/custom/action/Common/click.py
+++ b/agent/custom/action/Common/click.py
@@ -1,37 +1,37 @@
 import json
 
-from .utils import click_rect
+from .utils import click_rect, click_rect_720
 
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
+from utils.logger import logger
 
 
 @AgentServer.custom_action("click_override")
 class ClickOverride(CustomAction):
     def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
-        print("=== Click Action Started ===")
         controller = context.tasker.controller
-        
+
         if argv.custom_action_param is not None:
             try:
                 params = json.loads(argv.custom_action_param)
                 target = params.get("target")
                 if not target or len(target) != 4:
-                    print("Invalid rect parameter.")
+                    logger.warning(f"click_override invalid rect parameter: {argv.custom_action_param}")
                     return CustomAction.RunResult(success=False)
             except Exception as e:
-                print(f"Error parsing parameters: {e}")
+                logger.warning(f"click_override parse parameter failed: {e}")
                 return CustomAction.RunResult(success=False)
 
-            click_rect(controller, target, 0.005)
-            print(f"Clicked at rect: {target}")
+            click_rect_720(controller, target, 0.005)
+            logger.debug(f"click_override clicked baseline rect: {target}")
             return CustomAction.RunResult(success=True)
-        
+
         elif argv.reco_detail is not None:
             click_rect(controller, argv.box, 0.005)
             return CustomAction.RunResult(success=True)
-        
+
         else:
-            print("No valid parameters provided for click action.")
+            logger.warning("click_override missing parameters")
             return CustomAction.RunResult(success=False)

--- a/agent/custom/action/Common/utils.py
+++ b/agent/custom/action/Common/utils.py
@@ -30,6 +30,7 @@ def _rect_to_tuple(rect) -> tuple[int, int, int, int]:
 
 
 def click_point(controller, point: Sequence[int | float], delay=0.001, move=False):
+    """Click a point that is already in the current input/frame coordinate space."""
     x, y = point[:2]
     if move:
         controller.post_touch_move(round(x), round(y)).wait()
@@ -39,25 +40,30 @@ def click_point(controller, point: Sequence[int | float], delay=0.001, move=Fals
 
 
 def click_point_720(controller, point: Sequence[int | float], delay=0.001, move=False):
+    """Click a 1280x720-baseline point after mapping it to the current frame."""
     click_point(controller, screen.map_point_to_frame(point[0], point[1]), delay, move)
 
 
 def click_rect(controller, rect, delay=0.001, move=False):
+    """Click a rect that is already in the current input/frame coordinate space."""
     x, y, w, h = _rect_to_tuple(rect)
     click_point(controller, (x + w / 2, y + h / 2), delay, move)
 
 
 def click_rect_720(controller, rect, delay=0.001, move=False):
+    """Click a 1280x720-baseline rect after mapping it to the current frame."""
     click_rect(controller, screen.map_rect_to_frame(rect), delay, move)
 
 
 def swipe(controller, begin: Sequence[int | float], end: Sequence[int | float], duration=200):
+    """Swipe between points that are already in the current input/frame coordinate space."""
     begin_x, begin_y = begin[:2]
     end_x, end_y = end[:2]
     controller.post_swipe(round(begin_x), round(begin_y), round(end_x), round(end_y), duration).wait()
 
 
 def swipe_720(controller, begin: Sequence[int | float], end: Sequence[int | float], duration=200):
+    """Swipe between 1280x720-baseline points after mapping them to the current frame."""
     swipe(controller, screen.map_point_to_frame(begin[0], begin[1]), screen.map_point_to_frame(end[0], end[1]), duration)
 
 
@@ -126,14 +132,18 @@ def match_template_in_region_720(
 
     screen.update_frame_size_from_image(img)
     best = (False, 0.0, 0, 0)
+    scaled_templates = {}
 
     for candidate in screen.map_rect_to_frame_candidates(region):
-        scaled_template = screen.resize_template(
-            template,
-            candidate.scale_x,
-            candidate.scale_y,
-            green_mask=green_mask,
-        )
+        scale_key = (round(candidate.scale_x, 6), round(candidate.scale_y, 6), green_mask)
+        if scale_key not in scaled_templates:
+            scaled_templates[scale_key] = screen.resize_template(
+                template,
+                candidate.scale_x,
+                candidate.scale_y,
+                green_mask=green_mask,
+            )
+        scaled_template = scaled_templates[scale_key]
         hit, score, x, y = match_template_in_region(
             img,
             candidate.rect,

--- a/agent/custom/action/Common/utils.py
+++ b/agent/custom/action/Common/utils.py
@@ -1,51 +1,148 @@
-import cv2
 import time
+from collections.abc import Sequence
+
+import cv2
 import numpy as np
+
+from utils import screen
 
 
 def get_image(controller):
     job = controller.post_screencap()
     job.wait()
     img = controller.cached_image
+    screen.update_frame_size_from_image(img)
     return img
 
-def click_rect(controller, rect, delay=0.001):
-    x, y, w, h = rect
-    cx = x + w // 2
-    cy = y + h // 2
-    controller.post_touch_down(cx, cy).wait()
+
+def _rect_to_tuple(rect) -> tuple[int, int, int, int]:
+    if hasattr(rect, "x") and hasattr(rect, "y"):
+        width = getattr(rect, "w", getattr(rect, "width", None))
+        height = getattr(rect, "h", getattr(rect, "height", None))
+        if width is not None and height is not None:
+            return int(rect.x), int(rect.y), int(width), int(height)
+
+    if len(rect) < 4:
+        raise ValueError("rect must contain x, y, w, h")
+
+    x, y, w, h = rect[:4]
+    return int(x), int(y), int(w), int(h)
+
+
+def click_point(controller, point: Sequence[int | float], delay=0.001, move=False):
+    x, y = point[:2]
+    if move:
+        controller.post_touch_move(round(x), round(y)).wait()
+    controller.post_touch_down(round(x), round(y)).wait()
     time.sleep(delay)
     controller.post_touch_up().wait()
 
-def match_template_in_region(img, region, template, min_similarity=0.8, green_mask=False):
+
+def click_point_720(controller, point: Sequence[int | float], delay=0.001, move=False):
+    click_point(controller, screen.map_point_to_frame(point[0], point[1]), delay, move)
+
+
+def click_rect(controller, rect, delay=0.001, move=False):
+    x, y, w, h = _rect_to_tuple(rect)
+    click_point(controller, (x + w / 2, y + h / 2), delay, move)
+
+
+def click_rect_720(controller, rect, delay=0.001, move=False):
+    click_rect(controller, screen.map_rect_to_frame(rect), delay, move)
+
+
+def swipe(controller, begin: Sequence[int | float], end: Sequence[int | float], duration=200):
+    begin_x, begin_y = begin[:2]
+    end_x, end_y = end[:2]
+    controller.post_swipe(round(begin_x), round(begin_y), round(end_x), round(end_y), duration).wait()
+
+
+def swipe_720(controller, begin: Sequence[int | float], end: Sequence[int | float], duration=200):
+    swipe(controller, screen.map_point_to_frame(begin[0], begin[1]), screen.map_point_to_frame(end[0], end[1]), duration)
+
+
+def match_template_in_region(
+    img,
+    region,
+    template,
+    min_similarity=0.8,
+    green_mask=False,
+    scale_template=True,
+):
     if img is None or not isinstance(img, np.ndarray):
         return False, 0.0, 0, 0
-    
-    x1, y1, w, h = region
-    x2, y2 = x1 + w, y1 + h
-    
-    h, w = img.shape[:2]
-    x1, y1 = max(0, x1), max(0, y1)
-    x2, y2 = min(w, x2), min(h, y2)
-    
+
+    if template is None or not isinstance(template, np.ndarray):
+        return False, 0.0, 0, 0
+
+    screen.update_frame_size_from_image(img)
+    if scale_template:
+        template = screen.resize_template_to_frame(template, green_mask=green_mask)
+
+    img_h, img_w = img.shape[:2]
+    x1, y1, roi_w, roi_h = screen.clamp_rect(region, img_w, img_h)
+    x2, y2 = x1 + roi_w, y1 + roi_h
+
     if x2 <= x1 or y2 <= y1:
         return False, 0.0, 0, 0
-        
+
     roi = img[y1:y2, x1:x2]
-    
+
     if len(roi.shape) == 3 and roi.shape[2] == 4:
         roi = cv2.cvtColor(roi, cv2.COLOR_BGRA2BGR)
-    
+
+    if len(template.shape) == 3 and template.shape[2] == 4:
+        template = cv2.cvtColor(template, cv2.COLOR_BGRA2BGR)
+
+    if template.shape[0] > roi.shape[0] or template.shape[1] > roi.shape[1]:
+        return False, 0.0, 0, 0
+
     if green_mask:
         lower_green = np.array([0, 255, 0], dtype=np.uint8)
         upper_green = np.array([0, 255, 0], dtype=np.uint8)
         mask = cv2.bitwise_not(cv2.inRange(template, lower_green, upper_green))
         res = cv2.matchTemplate(roi, template, cv2.TM_CCOEFF_NORMED, mask=mask)
-
     else:
         res = cv2.matchTemplate(roi, template, cv2.TM_CCOEFF_NORMED)
+
     min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(res)
-    
+    if not np.isfinite(max_val):
+        return False, 0.0, 0, 0
+
     if max_val >= min_similarity:
         return True, max_val, x1 + max_loc[0], y1 + max_loc[1]
     return False, max_val, 0, 0
+
+
+def match_template_in_region_720(
+    img,
+    region,
+    template,
+    min_similarity=0.8,
+    green_mask=False,
+):
+    if img is None or not isinstance(img, np.ndarray):
+        return False, 0.0, 0, 0
+
+    screen.update_frame_size_from_image(img)
+    best = (False, 0.0, 0, 0)
+
+    for candidate in screen.map_rect_to_frame_candidates(region):
+        scaled_template = screen.resize_template(
+            template,
+            candidate.scale_x,
+            candidate.scale_y,
+            green_mask=green_mask,
+        )
+        hit, score, x, y = match_template_in_region(
+            img,
+            candidate.rect,
+            scaled_template,
+            min_similarity,
+            green_mask,
+            scale_template=False,
+        )
+        if score > best[1]:
+            best = (score >= min_similarity, score, x, y)
+
+    return best

--- a/agent/custom/action/Furniture/furniture_choose_property.py
+++ b/agent/custom/action/Furniture/furniture_choose_property.py
@@ -5,6 +5,7 @@ from maa.agent.agent_server import AgentServer
 from maa.context import Context
 from maa.custom_action import CustomAction
 
+from ..Common.utils import click_rect, get_image, swipe_720
 from utils.logger import logger
 
 _TOP_RESET_COUNT = 1
@@ -18,9 +19,7 @@ _NEXT_SWIPE_END = (160, 170)
 
 
 def _screencap(controller):
-    job = controller.post_screencap()
-    job.wait()
-    return controller.cached_image
+    return get_image(controller)
 
 
 def _box_to_rect(box):
@@ -30,19 +29,12 @@ def _box_to_rect(box):
 
 
 def _click_rect(controller, rect):
-    cx = rect[0] + rect[2] // 2
-    cy = rect[1] + rect[3] // 2
-    controller.post_touch_move(cx, cy).wait()
-    controller.post_touch_down(cx, cy).wait()
-    time.sleep(0.05)
-    controller.post_touch_up().wait()
+    click_rect(controller, rect, delay=0.05, move=True)
     time.sleep(0.05)
 
 
 def _swipe(controller, begin, end):
-    controller.post_swipe(
-        begin[0], begin[1], end[0], end[1], duration=_SWIPE_DURATION_MS
-    ).wait()
+    swipe_720(controller, begin, end, duration=_SWIPE_DURATION_MS)
     time.sleep(_SWIPE_DELAY_SEC)
 
 

--- a/agent/custom/action/auto_make_coffee.py
+++ b/agent/custom/action/auto_make_coffee.py
@@ -1,29 +1,24 @@
 import time
 import json
-import random
 
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
 
+from .Common.utils import click_rect as _click_rect_once
+from .Common.utils import click_rect_720 as _click_rect_720_once
+from .Common.utils import get_image
 from utils.maafocus import PrintT
 
 
-def get_image(controller):
-    job = controller.post_screencap()
-    job.wait()
-    img = controller.cached_image
-    return img
-
-
-def click_rect(controller, rect):
-    x, y, w, h = rect
-    cx = x + w // 2
-    cy = y + h // 2
+def click_rect(controller, rect, delay=0.05):
     for _ in range(3):
-        controller.post_touch_down(cx, cy).wait()
-        time.sleep(0.05)
-        controller.post_touch_up().wait()
+        _click_rect_once(controller, rect, delay)
+
+
+def click_rect_720(controller, rect, delay=0.05):
+    for _ in range(3):
+        _click_rect_720_once(controller, rect, delay)
 
 
 @AgentServer.custom_action("auto_make_coffee")
@@ -108,12 +103,12 @@ class AutoMakeCoffee(CustomAction):
             while True:
                 if context.tasker.stopping:
                     return CustomAction.RunResult(success=False)
-                click_rect(controller, click_roi)
+                click_rect_720(controller, click_roi, delay=0.05)
                 img = get_image(controller)
                 star_result = context.run_recognition("MakeCoffeeStar", img)
                 if star_result and star_result.hit:
                     PrintT(context, "coffee.step_star_click")
-                    click_rect(controller, exit_roi)
+                    click_rect_720(controller, exit_roi, delay=0.05)
                     time.sleep(1)
                     break
                 time.sleep(2)

--- a/agent/custom/action/pinkpaw/pinkpaw_core1.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core1.py
@@ -3,6 +3,7 @@ from maa.custom_action import CustomAction
 from maa.context import Context
 from maa.define import Status
 from datetime import datetime
+from utils import screen
 
 VK = {
     "W": 0x57,
@@ -29,7 +30,7 @@ def _is_hit(result) -> bool:
 class ActionHelper:
     def __init__(self, ctx: Context):
         self.ctx = ctx
-        self.mx, self.my = 640, 360
+        self.mx, self.my = screen.map_point_to_input(640, 360)
 
     # ---------- 按键类操作 ----------
     def _call_key(self, node_type, key_str, extra=None):
@@ -53,7 +54,7 @@ class ActionHelper:
         return self._call_key("KeyUp", key_str)
 
     # ---------- 鼠标操作 ----------
-    def move_to(self, x, y, duration_ms=None):
+    def _move_to_input(self, x, y, duration_ms=None):
         dx, dy = x - self.mx, y - self.my
         if dx * dx + dy * dy < 4:
             self.mx, self.my = x, y
@@ -78,8 +79,13 @@ class ActionHelper:
             self.mx, self.my = x, y
         return ret
 
+    def move_to(self, x, y, duration_ms=None):
+        x, y = screen.map_point_to_input(x, y)
+        return self._move_to_input(x, y, duration_ms)
+
     def click(self, x, y):
-        self.move_to(x, y)
+        x, y = screen.map_point_to_input(x, y)
+        self._move_to_input(x, y)
         override = {
             "PinkPawHeist_Click": {
                 "action": {"type": "Click", "param": {"target": [x, y]}}

--- a/agent/custom/action/pinkpaw/pinkpaw_core2.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core2.py
@@ -3,6 +3,7 @@ from maa.custom_action import CustomAction
 from maa.context import Context
 from maa.define import Status
 from datetime import datetime
+from utils import screen
 
 try:
     from agent.custom.action.pinkpaw.pinkpaw_reward_logger import notify_pinkpaw_reward
@@ -48,7 +49,7 @@ def _is_hit(result) -> bool:
 class ActionHelper:
     def __init__(self, ctx: Context):
         self.ctx = ctx
-        self.mx, self.my = 640, 360
+        self.mx, self.my = screen.map_point_to_input(640, 360)
         self.last_check_time = 0  # 增加记录上次检测时间的变量
         self.fail_count = 0
 
@@ -122,7 +123,7 @@ class ActionHelper:
         return self._call_key("KeyUp", key_str)
 
     # ---------- 鼠标操作 ----------
-    def move_to(self, x, y, duration_ms=None):
+    def _move_to_input(self, x, y, duration_ms=None):
         self.raise_if_stopped()
         dx, dy = x - self.mx, y - self.my
         if dx * dx + dy * dy < 4:
@@ -149,9 +150,14 @@ class ActionHelper:
             self.mx, self.my = x, y
         return ret
 
+    def move_to(self, x, y, duration_ms=None):
+        x, y = screen.map_point_to_input(x, y)
+        return self._move_to_input(x, y, duration_ms)
+
     def click(self, x, y):
         self.raise_if_stopped()
-        self.move_to(x, y)
+        x, y = screen.map_point_to_input(x, y)
+        self._move_to_input(x, y)
         override = {
             "PinkPawHeist_Click": {
                 "action": {"type": "Click", "param": {"target": [x, y]}}

--- a/agent/custom/action/rhythm/feats/select_song.py
+++ b/agent/custom/action/rhythm/feats/select_song.py
@@ -9,6 +9,7 @@ from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
 
+from utils import screen
 from utils.maafocus import PrintT
 
 from ..utils.config import load_rhythm_config
@@ -73,7 +74,11 @@ class AutoRhythmSelectSong(CustomAction):
             if state == STATE_SONG_SELECT:
                 scroll_fn = lambda sx, sy, sd: (
                     controller.post_swipe(
-                        sx, sy, sx, sy + sd * 100, duration=250
+                        sx,
+                        sy,
+                        sx,
+                        sy + round(sd * 100 * screen.frame_scaling_factors()[1]),
+                        duration=250,
                     ).wait(),
                     time.sleep(0.15),
                 )

--- a/agent/custom/action/rhythm/utils/song_selector.py
+++ b/agent/custom/action/rhythm/utils/song_selector.py
@@ -4,6 +4,8 @@ import logging
 import time
 from typing import Any, Callable
 
+from utils import screen
+
 logger = logging.getLogger(__name__)
 
 _SEL_IDLE = "idle"
@@ -111,6 +113,7 @@ class SongSelector:
         controller: Any,
         scroll_func: Callable[[int, int, int], None] | None = None,
     ) -> dict[str, Any]:
+        screen.update_frame_size_from_image(frame)
         now = time.perf_counter()
 
         if self._state == _SEL_IDLE:
@@ -151,8 +154,9 @@ class SongSelector:
             else:
                 self._consecutive_down_fails += 1
             if scroll_func is not None:
-                sx = self._song_list_roi[0] + self._song_list_roi[2] // 2
-                sy = self._song_list_roi[1] + self._song_list_roi[3] // 2
+                song_list_roi = screen.map_rect_to_frame(self._song_list_roi)
+                sx = song_list_roi[0] + song_list_roi[2] // 2
+                sy = song_list_roi[1] + song_list_roi[3] // 2
                 scroll_func(sx, sy, direction)
             self._scroll_attempts += 1
             self._last_action_time = now

--- a/agent/custom/action/withdraw_money_choose_item.py
+++ b/agent/custom/action/withdraw_money_choose_item.py
@@ -3,13 +3,12 @@ import re
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
+from .Common.utils import click_rect, get_image
 from utils.logger import logger
 
 
 def _screencap(controller):
-    job = controller.post_screencap()
-    job.wait()
-    return controller.cached_image
+    return get_image(controller)
 
 
 def _filtered_boxes(result):
@@ -30,12 +29,7 @@ def _box_to_rect(box):
 
 
 def _click_rect(controller, rect):
-    cx = rect[0] + rect[2] // 2
-    cy = rect[1] + rect[3] // 2
-    controller.post_touch_move(cx, cy).wait()  # 先移动再点击，防止误滑动
-    controller.post_touch_down(cx, cy).wait()
-    time.sleep(0.05)  # 间隔太短概率失效
-    controller.post_touch_up().wait()
+    click_rect(controller, rect, delay=0.05, move=True)  # 先移动再点击，防止误滑动
     time.sleep(0.05)
 
 

--- a/agent/main.py
+++ b/agent/main.py
@@ -542,14 +542,17 @@ def _check_game_resolution():
 
     w, h = size
     screen.update_screen_size(w, h)
+    screen.update_frame_size(w, h)
     scale_x, scale_y = screen.scaling_factors()
 
-    if (w, h) == (screen.BASELINE_WIDTH, screen.BASELINE_HEIGHT):
-        logger.info(f"当前窗口分辨率: {w}x{h} [正常], scale=({scale_x:.3f}, {scale_y:.3f})")
+    if screen.is_baseline_size(w, h):
+        logger.info(f"当前窗口分辨率: {w}x{h} [720p 基准], scale=({scale_x:.3f}, {scale_y:.3f})")
+    elif screen.is_supported_16_9(w, h):
+        logger.info(f"当前窗口分辨率: {w}x{h} [已启用 16:9 动态缩放], scale=({scale_x:.3f}, {scale_y:.3f})")
     else:
         logger.warning(
             f"当前窗口分辨率: {w}x{h}，scale=({scale_x:.3f}, {scale_y:.3f})。"
-            "请将游戏设置为 1280x720 窗口化模式，否则部分功能可能异常。"
+            "已启用非 16:9 兜底匹配，但固定点击仍建议使用 1280x720、1600x900、1920x1080 等 16:9 分辨率。"
         )
 
 

--- a/agent/utils/screen.py
+++ b/agent/utils/screen.py
@@ -1,41 +1,366 @@
 from __future__ import annotations
+
 from collections.abc import Sequence
+from typing import Any, NamedTuple
 
 BASELINE_WIDTH = 1280
 BASELINE_HEIGHT = 720
+BASELINE_ASPECT_RATIO = BASELINE_WIDTH / BASELINE_HEIGHT
 
 _current_width = BASELINE_WIDTH
 _current_height = BASELINE_HEIGHT
 _scale_x = 1.0
 _scale_y = 1.0
 
+_frame_width = BASELINE_WIDTH
+_frame_height = BASELINE_HEIGHT
+_frame_scale_x = 1.0
+_frame_scale_y = 1.0
+
+
+class RectMapping(NamedTuple):
+    name: str
+    rect: tuple[int, int, int, int]
+    scale_x: float
+    scale_y: float
+
+
+def _calc_scale(width: int, height: int) -> tuple[float, float]:
+    return width / BASELINE_WIDTH, height / BASELINE_HEIGHT
+
+
+def _has_size(width: int, height: int) -> bool:
+    return width > 0 and height > 0
+
 
 def current_size() -> tuple[int, int]:
+    """Return the currently detected game client/input size."""
     return _current_width, _current_height
 
 
+def frame_size() -> tuple[int, int]:
+    """Return the latest screenshot frame size."""
+    return _frame_width, _frame_height
+
+
 def scaling_factors() -> tuple[float, float]:
+    """Return scale factors from 1280x720 baseline to the current input size."""
     return _scale_x, _scale_y
 
 
+def frame_scaling_factors() -> tuple[float, float]:
+    """Return scale factors from 1280x720 baseline to the screenshot frame."""
+    return _frame_scale_x, _frame_scale_y
+
+
 def uniform_scale() -> float:
+    """Return a conservative uniform scale for input size-like values."""
     return min(_scale_x, _scale_y)
 
 
+def frame_uniform_scale() -> float:
+    """Return a conservative uniform scale for screenshot size-like values."""
+    return min(_frame_scale_x, _frame_scale_y)
+
+
+def is_baseline_size(width: int | None = None, height: int | None = None) -> bool:
+    width = _current_width if width is None else width
+    height = _current_height if height is None else height
+    return width == BASELINE_WIDTH and height == BASELINE_HEIGHT
+
+
+def is_supported_16_9(
+    width: int | None = None,
+    height: int | None = None,
+    *,
+    tolerance: float = 0.01,
+) -> bool:
+    width = _current_width if width is None else width
+    height = _current_height if height is None else height
+    if not _has_size(width, height):
+        return False
+
+    return abs((width / height) - BASELINE_ASPECT_RATIO) <= tolerance
+
+
 def update_screen_size(width: int, height: int) -> None:
-    """更新当前屏幕/游戏窗口尺寸并计算与基准分辨率的缩放系数。"""
+    """Update global input scale used by custom actions."""
     global _current_width, _current_height, _scale_x, _scale_y
+
+    if not _has_size(width, height):
+        return
+
     _current_width = int(width)
     _current_height = int(height)
-    _scale_x = _current_width / BASELINE_WIDTH if BASELINE_WIDTH else 1.0
-    _scale_y = _current_height / BASELINE_HEIGHT if BASELINE_HEIGHT else 1.0
+    _scale_x, _scale_y = _calc_scale(_current_width, _current_height)
 
 
-def map_point(x: int, y: int) -> Sequence[int]:
-    return int(round(x * _scale_x)), int(round(y * _scale_y))
+def update_frame_size(width: int, height: int) -> None:
+    """Update global screenshot scale used by image matching."""
+    global _frame_width, _frame_height, _frame_scale_x, _frame_scale_y
+
+    if not _has_size(width, height):
+        return
+
+    _frame_width = int(width)
+    _frame_height = int(height)
+    _frame_scale_x, _frame_scale_y = _calc_scale(_frame_width, _frame_height)
 
 
-def map_rect(rect: Sequence[int]) -> Sequence[int]:
-    x, y, w, h = rect
-    mapped_x, mapped_y = map_point(x, y)
-    return mapped_x, mapped_y, int(round(w * _scale_x)), int(round(h * _scale_y))
+def update_frame_size_from_image(image: Any) -> None:
+    """Update screenshot scale from a numpy-like image object."""
+    shape = getattr(image, "shape", None)
+    if shape is None or len(shape) < 2:
+        return
+
+    height, width = shape[:2]
+    update_frame_size(int(width), int(height))
+
+
+def _map_point(
+    x: int | float,
+    y: int | float,
+    scale_x: float,
+    scale_y: float,
+) -> tuple[int, int]:
+    return round(x * scale_x), round(y * scale_y)
+
+
+def _map_point_offset(
+    x: int | float,
+    y: int | float,
+    scale_x: float,
+    scale_y: float,
+    offset_x: float,
+    offset_y: float,
+) -> tuple[int, int]:
+    return round(offset_x + x * scale_x), round(offset_y + y * scale_y)
+
+
+def _map_rect(
+    rect: Sequence[int | float],
+    scale_x: float,
+    scale_y: float,
+) -> tuple[int, int, int, int]:
+    if len(rect) < 4:
+        raise ValueError("rect must contain x, y, w, h")
+
+    x, y, w, h = rect[:4]
+    x1, y1 = _map_point(x, y, scale_x, scale_y)
+    x2, y2 = _map_point(x + w, y + h, scale_x, scale_y)
+    return x1, y1, max(1, x2 - x1), max(1, y2 - y1)
+
+
+def _map_rect_offset(
+    rect: Sequence[int | float],
+    scale_x: float,
+    scale_y: float,
+    offset_x: float,
+    offset_y: float,
+) -> tuple[int, int, int, int]:
+    if len(rect) < 4:
+        raise ValueError("rect must contain x, y, w, h")
+
+    x, y, w, h = rect[:4]
+    x1, y1 = _map_point_offset(x, y, scale_x, scale_y, offset_x, offset_y)
+    x2, y2 = _map_point_offset(x + w, y + h, scale_x, scale_y, offset_x, offset_y)
+    return x1, y1, max(1, x2 - x1), max(1, y2 - y1)
+
+
+def _fit_transform(width: int, height: int) -> tuple[float, float, float, float]:
+    scale = min(width / BASELINE_WIDTH, height / BASELINE_HEIGHT)
+    offset_x = (width - BASELINE_WIDTH * scale) / 2
+    offset_y = (height - BASELINE_HEIGHT * scale) / 2
+    return scale, scale, offset_x, offset_y
+
+
+def _fill_transform(width: int, height: int) -> tuple[float, float, float, float]:
+    scale = max(width / BASELINE_WIDTH, height / BASELINE_HEIGHT)
+    offset_x = (width - BASELINE_WIDTH * scale) / 2
+    offset_y = (height - BASELINE_HEIGHT * scale) / 2
+    return scale, scale, offset_x, offset_y
+
+
+def _edge_aware_rect(
+    rect: Sequence[int | float],
+    width: int,
+    height: int,
+    scale: float,
+) -> tuple[int, int, int, int]:
+    if len(rect) < 4:
+        raise ValueError("rect must contain x, y, w, h")
+
+    x, y, w, h = rect[:4]
+    center_x = x + w / 2
+    center_y = y + h / 2
+
+    if center_x < BASELINE_WIDTH * 0.35:
+        mapped_x = round(x * scale)
+    elif center_x > BASELINE_WIDTH * 0.65:
+        mapped_x = round(width - (BASELINE_WIDTH - x) * scale)
+    else:
+        mapped_x = round(width / 2 + (center_x - BASELINE_WIDTH / 2) * scale - w * scale / 2)
+
+    if center_y < BASELINE_HEIGHT * 0.35:
+        mapped_y = round(y * scale)
+    elif center_y > BASELINE_HEIGHT * 0.65:
+        mapped_y = round(height - (BASELINE_HEIGHT - y) * scale)
+    else:
+        mapped_y = round(height / 2 + (center_y - BASELINE_HEIGHT / 2) * scale - h * scale / 2)
+
+    return mapped_x, mapped_y, max(1, round(w * scale)), max(1, round(h * scale))
+
+
+def map_point(x: int | float, y: int | float) -> tuple[int, int]:
+    """Map a 1280x720 point to the current input size."""
+    return map_point_to_input(x, y)
+
+
+def map_rect(rect: Sequence[int | float]) -> tuple[int, int, int, int]:
+    """Map a 1280x720 rect (x, y, w, h) to the current input size."""
+    return map_rect_to_input(rect)
+
+
+def map_point_to_input(x: int | float, y: int | float) -> tuple[int, int]:
+    return _map_point(x, y, _scale_x, _scale_y)
+
+
+def map_rect_to_input(rect: Sequence[int | float]) -> tuple[int, int, int, int]:
+    return _map_rect(rect, _scale_x, _scale_y)
+
+
+def map_point_to_frame(x: int | float, y: int | float) -> tuple[int, int]:
+    return _map_point(x, y, _frame_scale_x, _frame_scale_y)
+
+
+def map_rect_to_frame(rect: Sequence[int | float]) -> tuple[int, int, int, int]:
+    return _map_rect(rect, _frame_scale_x, _frame_scale_y)
+
+
+def map_rect_to_frame_fit(rect: Sequence[int | float]) -> tuple[int, int, int, int]:
+    scale_x, scale_y, offset_x, offset_y = _fit_transform(_frame_width, _frame_height)
+    return _map_rect_offset(rect, scale_x, scale_y, offset_x, offset_y)
+
+
+def map_rect_to_frame_candidates(rect: Sequence[int | float]) -> tuple[RectMapping, ...]:
+    """Return plausible frame-space mappings for a 1280x720 baseline rect."""
+    candidates: list[RectMapping] = [
+        RectMapping("stretch", map_rect_to_frame(rect), _frame_scale_x, _frame_scale_y)
+    ]
+
+    if not is_supported_16_9(_frame_width, _frame_height):
+        fit_scale_x, fit_scale_y, fit_offset_x, fit_offset_y = _fit_transform(_frame_width, _frame_height)
+        candidates.append(
+            RectMapping(
+                "fit",
+                _map_rect_offset(rect, fit_scale_x, fit_scale_y, fit_offset_x, fit_offset_y),
+                fit_scale_x,
+                fit_scale_y,
+            )
+        )
+
+        fill_scale_x, fill_scale_y, fill_offset_x, fill_offset_y = _fill_transform(_frame_width, _frame_height)
+        candidates.append(
+            RectMapping(
+                "fill",
+                _map_rect_offset(rect, fill_scale_x, fill_scale_y, fill_offset_x, fill_offset_y),
+                fill_scale_x,
+                fill_scale_y,
+            )
+        )
+
+        height_scale = _frame_height / BASELINE_HEIGHT
+        candidates.append(
+            RectMapping(
+                "edge_height",
+                _edge_aware_rect(rect, _frame_width, _frame_height, height_scale),
+                height_scale,
+                height_scale,
+            )
+        )
+
+        width_scale = _frame_width / BASELINE_WIDTH
+        candidates.append(
+            RectMapping(
+                "edge_width",
+                _edge_aware_rect(rect, _frame_width, _frame_height, width_scale),
+                width_scale,
+                width_scale,
+            )
+        )
+
+    unique: list[RectMapping] = []
+    seen: set[tuple[int, int, int, int, int, int]] = set()
+    for candidate in candidates:
+        clamped = clamp_rect(candidate.rect, _frame_width, _frame_height)
+        key = (
+            clamped[0],
+            clamped[1],
+            clamped[2],
+            clamped[3],
+            round(candidate.scale_x * 1000),
+            round(candidate.scale_y * 1000),
+        )
+        if clamped[2] <= 0 or clamped[3] <= 0 or key in seen:
+            continue
+        seen.add(key)
+        unique.append(RectMapping(candidate.name, clamped, candidate.scale_x, candidate.scale_y))
+
+    return tuple(unique)
+
+
+def clamp_rect(
+    rect: Sequence[int | float],
+    width: int,
+    height: int,
+) -> tuple[int, int, int, int]:
+    if len(rect) < 4:
+        raise ValueError("rect must contain x, y, w, h")
+
+    x, y, w, h = rect[:4]
+    x = max(0, min(int(x), width))
+    y = max(0, min(int(y), height))
+    w = max(0, min(int(w), width - x))
+    h = max(0, min(int(h), height - y))
+    return x, y, w, h
+
+
+def resize_template(
+    template: Any,
+    scale_x: float,
+    scale_y: float,
+    *,
+    green_mask: bool = False,
+) -> Any:
+    """Scale a baseline template by explicit x/y scale factors."""
+    if template is None:
+        return template
+
+    if abs(scale_x - 1.0) < 1e-3 and abs(scale_y - 1.0) < 1e-3:
+        return template
+
+    shape = getattr(template, "shape", None)
+    if shape is None or len(shape) < 2:
+        return template
+
+    height, width = shape[:2]
+    scaled_width = max(1, round(width * scale_x))
+    scaled_height = max(1, round(height * scale_y))
+    if scaled_width == width and scaled_height == height:
+        return template
+
+    import cv2
+
+    if green_mask:
+        interpolation = cv2.INTER_NEAREST
+    elif scale_x < 1.0 or scale_y < 1.0:
+        interpolation = cv2.INTER_AREA
+    else:
+        interpolation = cv2.INTER_CUBIC
+
+    return cv2.resize(template, (scaled_width, scaled_height), interpolation=interpolation)
+
+
+def resize_template_to_frame(template: Any, *, green_mask: bool = False) -> Any:
+    """Scale a 1280x720-baseline template to the latest screenshot frame."""
+    return resize_template(template, _frame_scale_x, _frame_scale_y, green_mask=green_mask)

--- a/agent/utils/screen.py
+++ b/agent/utils/screen.py
@@ -6,6 +6,9 @@ from typing import Any, NamedTuple
 BASELINE_WIDTH = 1280
 BASELINE_HEIGHT = 720
 BASELINE_ASPECT_RATIO = BASELINE_WIDTH / BASELINE_HEIGHT
+EDGE_ANCHOR_LEFT_TOP_RATIO = 0.35
+EDGE_ANCHOR_RIGHT_BOTTOM_RATIO = 0.65
+SCALE_KEY_PRECISION = 1000
 
 _current_width = BASELINE_WIDTH
 _current_height = BASELINE_HEIGHT
@@ -187,6 +190,7 @@ def _edge_aware_rect(
     height: int,
     scale: float,
 ) -> tuple[int, int, int, int]:
+    """Map HUD-like rects by anchoring near-edge regions to their nearest edge."""
     if len(rect) < 4:
         raise ValueError("rect must contain x, y, w, h")
 
@@ -194,16 +198,16 @@ def _edge_aware_rect(
     center_x = x + w / 2
     center_y = y + h / 2
 
-    if center_x < BASELINE_WIDTH * 0.35:
+    if center_x < BASELINE_WIDTH * EDGE_ANCHOR_LEFT_TOP_RATIO:
         mapped_x = round(x * scale)
-    elif center_x > BASELINE_WIDTH * 0.65:
+    elif center_x > BASELINE_WIDTH * EDGE_ANCHOR_RIGHT_BOTTOM_RATIO:
         mapped_x = round(width - (BASELINE_WIDTH - x) * scale)
     else:
         mapped_x = round(width / 2 + (center_x - BASELINE_WIDTH / 2) * scale - w * scale / 2)
 
-    if center_y < BASELINE_HEIGHT * 0.35:
+    if center_y < BASELINE_HEIGHT * EDGE_ANCHOR_LEFT_TOP_RATIO:
         mapped_y = round(y * scale)
-    elif center_y > BASELINE_HEIGHT * 0.65:
+    elif center_y > BASELINE_HEIGHT * EDGE_ANCHOR_RIGHT_BOTTOM_RATIO:
         mapped_y = round(height - (BASELINE_HEIGHT - y) * scale)
     else:
         mapped_y = round(height / 2 + (center_y - BASELINE_HEIGHT / 2) * scale - h * scale / 2)
@@ -243,7 +247,11 @@ def map_rect_to_frame_fit(rect: Sequence[int | float]) -> tuple[int, int, int, i
 
 
 def map_rect_to_frame_candidates(rect: Sequence[int | float]) -> tuple[RectMapping, ...]:
-    """Return plausible frame-space mappings for a 1280x720 baseline rect."""
+    """Return plausible frame-space mappings for a 1280x720 baseline rect.
+
+    The first candidate preserves the normal Maa-style stretch mapping. Non-16:9
+    frames add fit/fill and edge-anchored variants to cover common game layouts.
+    """
     candidates: list[RectMapping] = [
         RectMapping("stretch", map_rect_to_frame(rect), _frame_scale_x, _frame_scale_y)
     ]
@@ -298,8 +306,8 @@ def map_rect_to_frame_candidates(rect: Sequence[int | float]) -> tuple[RectMappi
             clamped[1],
             clamped[2],
             clamped[3],
-            round(candidate.scale_x * 1000),
-            round(candidate.scale_y * 1000),
+            round(candidate.scale_x * SCALE_KEY_PRECISION),
+            round(candidate.scale_y * SCALE_KEY_PRECISION),
         )
         if clamped[2] <= 0 or clamped[3] <= 0 or key in seen:
             continue


### PR DESCRIPTION
## 关联 Issue

需求来源：本地排查发现 MaaNTE 对 `1280x720` 依赖较强，需要支持异环在 16:9 高分辨率窗口/全屏下运行，并为非 16:9 场景提供更稳的识别兜底。无关联 Issue。

## 变更摘要

- 新增统一的分辨率/截图帧坐标工具，区分输入窗口尺寸与截图帧尺寸，支持 720p 基准坐标映射、模板缩放和非 16:9 候选 ROI 映射。
- 将钓鱼、买/卖鱼饵、咖啡、家具选择、取款商品、粉爪路线、节奏选歌等 Python CustomAction 接入动态坐标/ROI 缩放。
- 模板匹配新增 `match_template_in_region_720`，可在非 16:9 下尝试 stretch / fit / fill / edge-aware 等候选模型并取最高分。
- 启动时分辨率提示从“必须 1280x720”调整为 16:9 动态缩放提示，非 16:9 启用兜底匹配但仍建议 16:9。

## 验证

- [x] `python -m compileall -q agent` 通过。
- [x] `git diff --check` 通过。
- [x] Win32 DPI-aware 实机读取 `HTGame.exe` client size：`1920x1080`，scale `(1.5, 1.5)`，16:9 判定通过。
- [x] 使用真实 `1920x1080` 异环登录画面截图验证齿轮模板匹配：720p 模板自动缩放后命中 `[1847, 24]`，score `0.9622`。
- [x] 合成 `1440x900` 非 16:9 帧验证 stretch / fit / edge_height 三类候选映射均可命中，score 均为 `1.0`。

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

- 真实窗口验证基于本地异环 `HTGame.exe`，Windows 显示缩放 150% 下 DPI-aware 读取到真实 `1920x1080` client size。
- 外部窗口 resize 被游戏锁定，无法通过普通 `SetWindowPos` 自动切换更多尺寸；非 16:9 通过合成帧覆盖 stretch / fit / edge-aware 映射模型。

## Summary by Sourcery

添加分辨率感知的屏幕工具，并迁移交互和模板匹配逻辑，以支持从 1280x720 基线到任意窗口和画面尺寸（包括非 16:9 纵横比）的动态缩放。

新功能：
- 引入统一的屏幕和画面分辨率工具，用于将 1280x720 基线坐标和矩形映射到当前输入和截图尺寸。
- 添加模板缩放与多策略区域映射助手，以提升在非 16:9 分辨率下的模板匹配鲁棒性。
- 暴露基于 720p 的点击、滑动和模板匹配辅助方法，使自定义操作可以在基线坐标系中运行。

增强内容：
- 更新钓鱼、诱饵买卖、咖啡制作、家具选择、取出物品选择以及节奏歌曲选择等动作，改为使用动态坐标与 ROI 缩放，而不是固定的 1280x720 映射。
- 调整 PinkPaw 动作助手，使光标移动和点击通过分辨率感知的坐标映射进行。
- 优化启动时的分辨率检查日志，以区分 720p 基线、受支持的 16:9 分辨率以及非 16:9 回退模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a resolution-aware screen utility and migrate interaction and template matching logic to support dynamic scaling from a 1280x720 baseline to arbitrary window and frame sizes, including non-16:9 aspect ratios.

New Features:
- Introduce unified screen and frame resolution utilities for mapping 1280x720 baseline coordinates and rectangles to current input and screenshot sizes.
- Add template resizing and multi-strategy region mapping helpers to improve template matching robustness on non-16:9 resolutions.
- Expose 720p-based click, swipe, and template matching helpers for custom actions to operate in baseline coordinates.

Enhancements:
- Update fishing, bait buying/selling, coffee making, furniture selection, withdraw item selection, and rhythm song selection actions to use dynamic coordinate and ROI scaling instead of fixed 1280x720 mappings.
- Adjust PinkPaw action helpers to route cursor movement and clicking through resolution-aware coordinate mapping.
- Refine resolution check logging at startup to distinguish 720p baseline, supported 16:9 resolutions, and non-16:9 fallback modes.

</details>