### PR TITLE
Add docstring to __getattr__ function in SoundTrigger module

### DIFF
--- a/agent/custom/action/SoundTrigger/__init__.py
+++ b/agent/custom/action/SoundTrigger/__init__.py
@@ -2,6 +2,20 @@ __all__ = ["Ear", "Dodger"]
 
 
 def __getattr__(name: str):
+    """Lazy import of module attributes.
+
+    This function allows lazy importing of the Ear and Dodger classes
+    when accessed as module attributes.
+
+    Args:
+        name (str): The name of the attribute to import.
+
+    Returns:
+        The requested class.
+
+    Raises:
+        AttributeError: If the attribute name is not in __all__.
+    """
     if name == "Ear":
         from .SoundListener import Ear
         return Ear


### PR DESCRIPTION
## Problem
The public `__getattr__` function in `agent/custom/action/SoundTrigger/__init__.py` was missing a docstring, which is a best practice for code readability and maintainability in Python. This omission could hinder understanding of the function's purpose, especially for new contributors.

## Changes
- Added a detailed docstring to the `__getattr__` function, covering:
  - **Description**: Lazy import of `Ear` and `Dodger` classes when accessed as module attributes.
  - **Arguments**: `name (str)` - the attribute name to import.
  - **Returns**: The requested class.
  - **Raises**: `AttributeError` if the name is not in `__all__`.

## Verification
- The function's external behavior and API remain unchanged; it still supports lazy imports of `Ear` and `Dodger`.
- No functional changes, so existing tests or manual verification (e.g., importing `Ear` or `Dodger` from the module) should continue to work as expected.

## Summary by Sourcery

文档：
- 为 `SoundTrigger` 的 `__getattr__` 函数添加文档字符串，描述其延迟导入行为、参数、返回值以及可能引发的 `AttributeError`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add a docstring to the SoundTrigger __getattr__ function describing its lazy import behavior, arguments, return value, and possible AttributeError.

</details>