### PR TITLE
Fix(furniture):修复家具furniture_claim.py脚本的拼写错误

### DIFF
--- a/agent/custom/action/Furniture/furniture_claim.py
+++ b/agent/custom/action/Furniture/furniture_claim.py
@@ -28,14 +28,14 @@ class FurnitureClaim(CustomAction):
                     "FurnitureClaim",
                     image,
                     pipeline_override={
-                        "FurnitureClaim": {"recogniton": {"param": roi}}
+                        "FurnitureClaim": {"recognition": {"param": roi}}
                     },
                 )
                 if result.hit:
                     context.run_task(
                         "FurnitureClaim",
                         pipeline_override={
-                            "FurnitureClaim": {"recogniton": {"param": roi}}
+                            "FurnitureClaim": {"recognition": {"param": roi}}
                         },
                     )
                     PrintT(context, f"furniture.claimed.{msg_key}")

--- a/agent/custom/action/Furniture/furniture_claim.py
+++ b/agent/custom/action/Furniture/furniture_claim.py
@@ -28,14 +28,14 @@ class FurnitureClaim(CustomAction):
                     "FurnitureClaim",
                     image,
                     pipeline_override={
-                        "FurnitureClaim": {"recognition": {"param": roi}}
+                        "FurnitureClaim": {"roi": roi}
                     },
                 )
                 if result.hit:
                     context.run_task(
                         "FurnitureClaim",
                         pipeline_override={
-                            "FurnitureClaim": {"recognition": {"param": roi}}
+                            "FurnitureClaim": {"roi": roi}
                         },
                     )
                     PrintT(context, f"furniture.claimed.{msg_key}")


### PR DESCRIPTION
1、修复了FurnitureClaim下recognition拼成recogniton的错误
2、修复了pipeline_override覆写FurnitureClaim时，roi的标题错误，应为"roi": roi

## Summary by Sourcery

错误修复：
- 将 FurnitureClaim 在运行和重新运行 FurnitureClaim 任务时使用的 `pipeline_override` 键，从拼写错误的识别字段更正为正确的 `roi` 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the FurnitureClaim pipeline_override key from a misspelled recognition field to the proper roi configuration when running and re-running the FurnitureClaim task.

</details>