### PR TITLE
fix(auto_f_scroll): 修复粉爪快速拾取未按F时循环空转导致日志爆炸

### DIFF
--- a/agent/custom/action/auto_f_scroll.py
+++ b/agent/custom/action/auto_f_scroll.py
@@ -33,9 +33,11 @@ class AutoFScroll(CustomAction):
                     # 参数: dwFlags, dx, dy, dwData(滚轮幅度), dwExtraInfo
                     # -120 代表向下滚动一格
                     ctypes.windll.user32.mouse_event(MOUSEEVENTF_WHEEL, 0, 0, -120, 0)
-                except Exception as e:
+                except Exception:
                     pass
 
                 time.sleep(0.1)
+            else:
+                time.sleep(0.05)  # 没按F时避免空转，避免日志爆炸
 
         return CustomAction.RunResult(success=True)


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

Related #292 

## 变更摘要

在 while 循环的 else 分支添加 time.sleep(0.05)，并且移除未使用的变量

## 验证

开启实时辅助下的 粉爪快速拾取(按住F触发) 功能，进入粉爪大劫案。任何设备均可触发。

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

循环空转，每秒约 1,577 次迭代，每次迭代触发 MaaTaskerStopping IPC 调用，产生 2 行日志，14 分钟产生 3GB 日志
<img width="1505" height="759" alt="image" src="https://github.com/user-attachments/assets/bc03803e-8b60-4205-b669-0cc7b5f035b6" />

## Summary by Sourcery

Bug Fixes:
- 通过在空闲路径中添加一个短暂延迟，防止在未按住 F 键时自动 F 滚动进入忙等待并疯狂输出日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent auto F scroll from busy-waiting and spamming logs when the F key is not held by adding a small delay in the idle path.

</details>