### PR TITLE
chore: 修复了release失败的问题

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -267,20 +267,32 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          path: assets
+          path: downloaded-artifacts
 
       - name: Process and package artifacts
+        shell: bash
         run: |
-          cd assets
-          for f in *; do
-            if [[ $f == *"win"* ]]; then
-              (cd "$f" && zip -r "../$f.zip" .)
+          artifact_dir="$PWD/downloaded-artifacts"
+          release_dir="$PWD/release-assets"
+          mkdir -p "$release_dir"
+
+          for f in "$artifact_dir"/*; do
+            artifact_name="$(basename "$f")"
+
+            if [[ ! -d "$f" ]]; then
+              echo "Skipping non-directory artifact entry: $artifact_name"
+              continue
+            fi
+
+            if [[ $artifact_name == *"win"* ]]; then
+              echo "Processing Windows artifact: $artifact_name"
+              (cd "$f" && zip -r "$release_dir/$artifact_name.zip" .)
             else
-              echo "Processing Unix artifact: $f"
+              echo "Processing Unix artifact: $artifact_name"
 
               if [[ -f "$f/MaaPiCli" ]]; then
                 chmod +x "$f/MaaPiCli"
-                echo "Set execute permission for $f/MaaPiCli"
+                echo "Set execute permission for $artifact_name/MaaPiCli"
               fi
 
               find "$f" -type f -name "MFAUpdater*" -exec chmod +x {} \; 2>/dev/null || true
@@ -288,30 +300,29 @@ jobs:
 
               if [[ -f "$f/MaaNTE" ]]; then
                 chmod +x "$f/MaaNTE"
-                echo "Set execute permission for $f/MaaNTE"
+                echo "Set execute permission for $artifact_name/MaaNTE"
               fi
 
-              PYTHON_PATHS=(
-                "$f/python/bin/python3"
-                "$f/python/python"
-                "$f/python/bin/python"
-                "$f/python/python.exe"
-              )
-              for PYTHON_PATH in "${PYTHON_PATHS[@]}"; do
+              for PYTHON_PATH in "$f/python/bin/python3" "$f/python/python" "$f/python/bin/python" "$f/python/python.exe"; do
                 if [[ -f "$PYTHON_PATH" ]]; then
                   chmod +x "$PYTHON_PATH"
-                  echo "Set execute permission for $PYTHON_PATH"
+                  echo "Set execute permission for ${PYTHON_PATH#$artifact_dir/}"
                 fi
               done
 
-              tar -cpzf "$f.tar.gz" -C "$f" .
-              echo "Created archive with preserved permissions: $f.tar.gz"
+              tar -cpzf "$release_dir/$artifact_name.tar.gz" -C "$f" .
+              echo "Created archive with preserved permissions: $artifact_name.tar.gz"
             fi
           done
 
+          if [[ -z "$(find "$release_dir" -maxdepth 1 -type f -print -quit)" ]]; then
+            echo "No release assets were created."
+            exit 1
+          fi
+
       - uses: softprops/action-gh-release@v2.2.2
         with:
-          files: assets/*
+          files: release-assets/*
           tag_name: ${{ needs.meta.outputs.tag }}
           body_path: CHANGES.md
           draft: false


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

无

## 变更摘要

artifact 下载到 downloaded-artifacts/，不再污染源码 assets/
打包输出写到 release-assets/
循环只处理目录，遇到普通文件会跳过
release 只上传 release-assets/*
给打包 step 显式加了 shell: bash

## 验证

git diff --check 通过
本地模拟了 Windows artifact、Unix artifact 和混入的 interface.json，结果 interface.json 被跳过，并生成了 .zip / .tar.gz 包。

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

<!-- 涉及识别、点击、界面跳转或 Bug 修复时，请提供截图、ROI、模板路径或 maa.log 关键片段。 -->
