### PR TITLE
fix(ClaimRewards): 修复领取活跃度奖励识别不到确认

### DIFF
--- a/assets/resource/base/pipeline/ClaimRewards.json
+++ b/assets/resource/base/pipeline/ClaimRewards.json
@@ -34,6 +34,7 @@
             }
         },
         "action": "Click",
+        "post_delay": 500,
         "next": [
             "[JumpBack]ClaimRewardsActivityPoints",
             "[JumpBack]ClaimRewardsActivityRewards",


### PR DESCRIPTION
## 关联 Issue
#301 
1.将ClaimRewards中的ClaimRewardsActivitySwitchToPage2节点添加一个500ms的post_delay

## Summary by Sourcery

Bug Fixes:
- 在 `ClaimRewardsActivitySwitchToPage2` 节点中添加 500ms 的后置延迟，以防止奖励确认状态的检测被遗漏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a 500ms post-delay to the ClaimRewardsActivitySwitchToPage2 node to prevent missed detection of the reward confirmation state.

</details>