### PR TITLE
fix(Furniture): 修复 FurnitureClickHouseProperty 因动画未完成导致 OCR 识别后点击过快

### DIFF
--- a/assets/resource/base/pipeline/Furniture/Furniture.json
+++ b/assets/resource/base/pipeline/Furniture/Furniture.json
@@ -23,6 +23,7 @@
             "不動産",
             "부동산"
         ],
+        "pre_delay": 500,
         "action": "Click",
         "next": [
             "FurnitureChooseApartments"

--- a/assets/resource/base/pipeline/Furniture/Furniture.json
+++ b/assets/resource/base/pipeline/Furniture/Furniture.json
@@ -23,7 +23,7 @@
             "不動産",
             "부동산"
         ],
-        "pre_delay": 500,
+        "pre_wait_freezes": 200,
         "action": "Click",
         "next": [
             "FurnitureChooseApartments"


### PR DESCRIPTION
- FurnitureClickHouseProperty 增加"pre_wait_freezes": 200，在 OCR 识别前等待画面静止，确保房产菜单动画完全加载后再点击

## Summary by Sourcery

Bug Fixes:
- 在 `FurnitureClickHouseProperty` 中添加点击前的冻结/等待步骤，以确保基于 OCR 的点击只会在家具菜单动画完全完成后才触发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a pre-click freeze/wait in FurnitureClickHouseProperty so OCR-based clicks occur only after the furniture menu animation has fully completed.

</details>