### PR TITLE
fix(make_coffee):修改做咖啡pipeline_override参数错误

### DIFF
--- a/assets/resource/tasks/MakeCoffee.json
+++ b/assets/resource/tasks/MakeCoffee.json
@@ -28,7 +28,7 @@
                 }
             ],
             "pipeline_override": {
-                "AutoMakeCoffee": {
+                "MakeCoffeeRun": {
                     "custom_action_param": {
                         "count": "{LoopTime}"
                     }


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

#324 

## 变更摘要

修改tasks/MakeCoffee.json中选项MakeCoffeeLoopTime下pipeline_override覆盖的节点为MakeCoffeeRun


- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## Summary by Sourcery

Bug Fixes:
- 修复 `MakeCoffee.json` 中 `MakeCoffeeLoopTime` 的 `pipeline_override` 配置错误，现在它会正确地指向 `MakeCoffeeRun` 节点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix misconfigured pipeline_override for MakeCoffeeLoopTime in MakeCoffee.json so it targets the MakeCoffeeRun node.

</details>