### PR TITLE
feat(PinkPawHeist): 支持脚本启动前自动设置游戏分辨率并添加公共节点

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@
   《明日方舟》小助手，全日常一键长草！
 - [MaaEnd](https://github.com/MaaEnd/MaaEnd)
   基于视觉 AI 的「明日方舟：终末地」自动化工具
+- [OK-NTE](https://github.com/BnanZ0/ok-nte)
+  一款基于图像识别的《异环》自动化工具，支持后台运行。
 - [M9A](https://github.com/MAA1999/M9A)
   重返未来：1999 小助手
 - ~~[MFAAvalonia](https://github.com/SweetSmellFox/MFAAvalonia)

--- a/agent/custom/action/Common/resize_game_window.py
+++ b/agent/custom/action/Common/resize_game_window.py
@@ -1,0 +1,113 @@
+import json
+import sys
+
+from maa.agent.agent_server import AgentServer
+from maa.custom_action import CustomAction
+from maa.context import Context
+
+from utils.logger import logger
+
+DEFAULT_WIDTH = 1280
+DEFAULT_HEIGHT = 720
+
+if sys.platform == "win32":
+    try:
+        from utils.win32_process import ensure_game_window_resolution
+    except Exception:
+        ensure_game_window_resolution = None
+else:
+    ensure_game_window_resolution = None
+
+
+def _parse_bool(value, default=False):
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
+    return bool(default)
+
+
+def _parse_resize_params(raw_param):
+    if not raw_param:
+        return DEFAULT_WIDTH, DEFAULT_HEIGHT
+
+    if isinstance(raw_param, dict):
+        params = raw_param
+    else:
+        try:
+            params = json.loads(raw_param)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"invalid custom_action_param: {exc}") from exc
+
+    if not isinstance(params, dict):
+        raise ValueError("custom_action_param must be an object")
+
+    resolution = params.get("resolution")
+    if resolution is not None:
+        if not isinstance(resolution, (list, tuple)) or len(resolution) != 2:
+            raise ValueError("resolution must be [width, height]")
+        width, height = resolution
+    else:
+        width = params.get("width", DEFAULT_WIDTH)
+        height = params.get("height", DEFAULT_HEIGHT)
+
+    width = int(width)
+    height = int(height)
+    if width <= 0 or height <= 0:
+        raise ValueError("width and height must be positive")
+
+    return width, height
+
+
+def _parse_optional_resize_kwargs(raw_param):
+    if not raw_param:
+        return {}
+    if isinstance(raw_param, dict):
+        params = raw_param
+    else:
+        params = json.loads(raw_param)
+    if not isinstance(params, dict):
+        return {}
+
+    kwargs = {}
+    if "process_name" in params:
+        kwargs["process_name"] = str(params["process_name"])
+    if "center" in params:
+        kwargs["center"] = _parse_bool(params["center"], True)
+    if "tolerance" in params:
+        kwargs["tolerance"] = int(params["tolerance"])
+    if "settle_ms" in params:
+        kwargs["settle_ms"] = int(params["settle_ms"])
+    return kwargs
+
+
+@AgentServer.custom_action("resize_game_window")
+class ResizeGameWindow(CustomAction):
+    def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
+        try:
+            width, height = _parse_resize_params(argv.custom_action_param)
+            kwargs = _parse_optional_resize_kwargs(argv.custom_action_param)
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            logger.warning("resize_game_window 参数解析失败: %s", exc)
+            return CustomAction.RunResult(success=False)
+
+        if ensure_game_window_resolution is None:
+            logger.warning("resize_game_window 仅支持 Windows 或 win32_process 不可用")
+            return CustomAction.RunResult(success=False)
+
+        try:
+            result = ensure_game_window_resolution(width, height, **kwargs)
+        except Exception as exc:
+            logger.exception("resize_game_window 执行失败: %s", exc)
+            return CustomAction.RunResult(success=False)
+
+        success = bool(result.get("success")) if isinstance(result, dict) else bool(result)
+        if success:
+            logger.debug("resize_game_window 成功: %s", result)
+        else:
+            logger.warning("resize_game_window 失败: %s", result)
+        return CustomAction.RunResult(success=success)

--- a/agent/custom/action/__init__.py
+++ b/agent/custom/action/__init__.py
@@ -7,6 +7,7 @@ from .rhythm.feats.play import *
 from .rhythm.feats.repeat_decision import *
 from .rhythm.feats.select_song import *
 from .Common.click import *
+from .Common.resize_game_window import *
 from .realtime_task import *
 from .Navi import *
 from .pinkpaw.pinkpaw_core1 import *
@@ -36,6 +37,7 @@ __all__ = [
     "AutoBuyFishBait",
     "AutoSellFish",
     "ClickOverride",
+    "ResizeGameWindow",
     "AutoTetris",
     "AutoRhythmPlay",
     "AutoRhythmRepeatDecision",

--- a/agent/custom/action/pinkpaw/pinkpaw_common.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_common.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+from maa.custom_action import CustomAction
+from maa.context import Context
+
+
+AUTO_RESIZE_CONFIG_NODE = "PinkPawHeist_AutoResizeGameWindowConfig"
+
+
+def _parse_custom_action_param(
+    argv: CustomAction.RunArg,
+    log_prefix="[PinkPawHeist]",
+) -> dict:
+    value = getattr(argv, "custom_action_param", None)
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return value
+    try:
+        parsed = json.loads(value)
+    except Exception as exc:
+        print(f"{log_prefix} invalid custom_action_param: {value!r}, error: {exc}")
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _parse_bool(value, default=False) -> bool:
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
+    return bool(default)
+
+
+def _get_auto_resize_game_window(ctx: Context, default=True) -> bool:
+    try:
+        node_data = ctx.get_node_data(AUTO_RESIZE_CONFIG_NODE) or {}
+    except Exception:
+        return bool(default)
+    attach = node_data.get("attach") if isinstance(node_data, dict) else None
+    if isinstance(attach, dict) and "auto_resize_game_window" in attach:
+        return _parse_bool(attach.get("auto_resize_game_window"), default)
+    return bool(default)

--- a/agent/custom/action/pinkpaw/pinkpaw_common.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_common.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
 import json
+import sys
 
 from maa.custom_action import CustomAction
 from maa.context import Context
 
 
+DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
 AUTO_RESIZE_CONFIG_NODE = "PinkPawHeist_AutoResizeGameWindowConfig"
+
+if sys.platform == "win32":
+    try:
+        try:
+            from agent.utils.win32_process import ensure_game_window_resolution
+        except ImportError:
+            from utils.win32_process import ensure_game_window_resolution
+    except ImportError:
+        ensure_game_window_resolution = None
+else:
+    ensure_game_window_resolution = None
 
 
 def _parse_custom_action_param(
@@ -38,7 +51,10 @@ def _parse_bool(value, default=False) -> bool:
     return bool(default)
 
 
-def _get_auto_resize_game_window(ctx: Context, default=True) -> bool:
+def _get_auto_resize_game_window(
+    ctx: Context,
+    default=DEFAULT_AUTO_RESIZE_GAME_WINDOW,
+) -> bool:
     try:
         node_data = ctx.get_node_data(AUTO_RESIZE_CONFIG_NODE) or {}
     except Exception:

--- a/agent/custom/action/pinkpaw/pinkpaw_core1.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core1.py
@@ -5,29 +5,22 @@ from maa.define import Status
 from datetime import datetime
 
 try:
-    try:
-        from agent.utils.win32_process import ensure_game_window_resolution
-    except ImportError:
-        from utils.win32_process import ensure_game_window_resolution
-except Exception:
-    ensure_game_window_resolution = None
-
-try:
     from agent.custom.action.pinkpaw.pinkpaw_common import (
         _get_auto_resize_game_window,
         _parse_bool,
         _parse_custom_action_param,
+        ensure_game_window_resolution,
     )
 except ImportError:
     from .pinkpaw_common import (
         _get_auto_resize_game_window,
         _parse_bool,
         _parse_custom_action_param,
+        ensure_game_window_resolution,
     )
 
 DEFAULT_WIDTH = 1280
 DEFAULT_HEIGHT = 720
-DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
 
 VK = {
     "W": 0x57,

--- a/agent/custom/action/pinkpaw/pinkpaw_core1.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core1.py
@@ -1,8 +1,22 @@
+import json
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
 from maa.define import Status
 from datetime import datetime
+
+try:
+    try:
+        from agent.utils.win32_process import ensure_game_window_resolution
+    except ImportError:
+        from utils.win32_process import ensure_game_window_resolution
+except Exception:
+    ensure_game_window_resolution = None
+
+DEFAULT_WIDTH = 1280
+DEFAULT_HEIGHT = 720
+DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
+AUTO_RESIZE_CONFIG_NODE = "PinkPawHeist_AutoResizeGameWindowConfig"
 
 VK = {
     "W": 0x57,
@@ -24,6 +38,45 @@ def _is_hit(result) -> bool:
     if result is None:
         return False
     return result.status == 0  # 0 = MaaStatus.Success
+
+
+def _parse_custom_action_param(argv: CustomAction.RunArg) -> dict:
+    value = getattr(argv, "custom_action_param", None)
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return value
+    try:
+        parsed = json.loads(value)
+    except Exception as exc:
+        print(
+            f"[PinkPawHeist/Core1] invalid custom_action_param: {value!r}, error: {exc}"
+        )
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _parse_bool(value, default=False) -> bool:
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
+    return bool(default)
+
+
+def _get_auto_resize_game_window(ctx: Context, default=DEFAULT_AUTO_RESIZE_GAME_WINDOW):
+    try:
+        node_data = ctx.get_node_data(AUTO_RESIZE_CONFIG_NODE) or {}
+    except Exception:
+        return bool(default)
+    attach = node_data.get("attach") if isinstance(node_data, dict) else None
+    if isinstance(attach, dict) and "auto_resize_game_window" in attach:
+        return _parse_bool(attach.get("auto_resize_game_window"), default)
+    return bool(default)
 
 
 class ActionHelper:
@@ -185,6 +238,14 @@ class PinkPawHeistScheme1Action(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
+        params = _parse_custom_action_param(argv)
+        auto_resize_default = _get_auto_resize_game_window(context)
+        auto_resize = _parse_bool(
+            params.get("auto_resize_game_window"),
+            auto_resize_default,
+        )
+        if auto_resize and ensure_game_window_resolution:
+            ensure_game_window_resolution(DEFAULT_WIDTH, DEFAULT_HEIGHT)
         ah = ActionHelper(context)
 
         # ----- 切换3号，前往铁门 -----

--- a/agent/custom/action/pinkpaw/pinkpaw_core1.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core1.py
@@ -1,4 +1,3 @@
-import json
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
@@ -13,10 +12,22 @@ try:
 except Exception:
     ensure_game_window_resolution = None
 
+try:
+    from agent.custom.action.pinkpaw.pinkpaw_common import (
+        _get_auto_resize_game_window,
+        _parse_bool,
+        _parse_custom_action_param,
+    )
+except ImportError:
+    from .pinkpaw_common import (
+        _get_auto_resize_game_window,
+        _parse_bool,
+        _parse_custom_action_param,
+    )
+
 DEFAULT_WIDTH = 1280
 DEFAULT_HEIGHT = 720
 DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
-AUTO_RESIZE_CONFIG_NODE = "PinkPawHeist_AutoResizeGameWindowConfig"
 
 VK = {
     "W": 0x57,
@@ -38,45 +49,6 @@ def _is_hit(result) -> bool:
     if result is None:
         return False
     return result.status == 0  # 0 = MaaStatus.Success
-
-
-def _parse_custom_action_param(argv: CustomAction.RunArg) -> dict:
-    value = getattr(argv, "custom_action_param", None)
-    if not value:
-        return {}
-    if isinstance(value, dict):
-        return value
-    try:
-        parsed = json.loads(value)
-    except Exception as exc:
-        print(
-            f"[PinkPawHeist/Core1] invalid custom_action_param: {value!r}, error: {exc}"
-        )
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
-
-
-def _parse_bool(value, default=False) -> bool:
-    if value is None:
-        return bool(default)
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
-    return bool(default)
-
-
-def _get_auto_resize_game_window(ctx: Context, default=DEFAULT_AUTO_RESIZE_GAME_WINDOW):
-    try:
-        node_data = ctx.get_node_data(AUTO_RESIZE_CONFIG_NODE) or {}
-    except Exception:
-        return bool(default)
-    attach = node_data.get("attach") if isinstance(node_data, dict) else None
-    if isinstance(attach, dict) and "auto_resize_game_window" in attach:
-        return _parse_bool(attach.get("auto_resize_game_window"), default)
-    return bool(default)
 
 
 class ActionHelper:
@@ -238,7 +210,7 @@ class PinkPawHeistScheme1Action(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
-        params = _parse_custom_action_param(argv)
+        params = _parse_custom_action_param(argv, log_prefix="[PinkPawHeist/Core1]")
         auto_resize_default = _get_auto_resize_game_window(context)
         auto_resize = _parse_bool(
             params.get("auto_resize_game_window"),

--- a/agent/custom/action/pinkpaw/pinkpaw_core2.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core2.py
@@ -1,4 +1,3 @@
-import json
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
@@ -12,6 +11,19 @@ try:
         from utils.win32_process import ensure_game_window_resolution
 except Exception:
     ensure_game_window_resolution = None
+
+try:
+    from agent.custom.action.pinkpaw.pinkpaw_common import (
+        _get_auto_resize_game_window,
+        _parse_bool,
+        _parse_custom_action_param,
+    )
+except ImportError:
+    from .pinkpaw_common import (
+        _get_auto_resize_game_window,
+        _parse_bool,
+        _parse_custom_action_param,
+    )
 
 try:
     from agent.custom.action.pinkpaw.pinkpaw_reward_logger import notify_pinkpaw_reward
@@ -38,7 +50,6 @@ POST_REWARD_DELAY_MS = 7000
 DEFAULT_WIDTH = 1280
 DEFAULT_HEIGHT = 720
 DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
-AUTO_RESIZE_CONFIG_NODE = "PinkPawHeist_AutoResizeGameWindowConfig"
 
 
 class StopActionException(Exception):
@@ -56,45 +67,6 @@ def _is_hit(result) -> bool:
     if result.status.succeeded is False:
         return False
     return True
-
-
-def _parse_custom_action_param(argv: CustomAction.RunArg) -> dict:
-    value = getattr(argv, "custom_action_param", None)
-    if not value:
-        return {}
-    if isinstance(value, dict):
-        return value
-    try:
-        parsed = json.loads(value)
-    except Exception as exc:
-        print(
-            f"[PinkPawHeist/Core2] invalid custom_action_param: {value!r}, error: {exc}"
-        )
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
-
-
-def _parse_bool(value, default=False) -> bool:
-    if value is None:
-        return bool(default)
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
-    return bool(default)
-
-
-def _get_auto_resize_game_window(ctx: Context, default=DEFAULT_AUTO_RESIZE_GAME_WINDOW):
-    try:
-        node_data = ctx.get_node_data(AUTO_RESIZE_CONFIG_NODE) or {}
-    except Exception:
-        return bool(default)
-    attach = node_data.get("attach") if isinstance(node_data, dict) else None
-    if isinstance(attach, dict) and "auto_resize_game_window" in attach:
-        return _parse_bool(attach.get("auto_resize_game_window"), default)
-    return bool(default)
 
 
 class ActionHelper:
@@ -378,7 +350,7 @@ class PinkPawHeistScheme2Action(CustomAction):
     ) -> CustomAction.RunResult:
         ah = ActionHelper(context)
         try:
-            params = _parse_custom_action_param(argv)
+            params = _parse_custom_action_param(argv, log_prefix="[PinkPawHeist/Core2]")
             auto_resize_default = _get_auto_resize_game_window(context)
             auto_resize = _parse_bool(
                 params.get("auto_resize_game_window"),

--- a/agent/custom/action/pinkpaw/pinkpaw_core2.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core2.py
@@ -5,24 +5,18 @@ from maa.define import Status
 from datetime import datetime
 
 try:
-    try:
-        from agent.utils.win32_process import ensure_game_window_resolution
-    except ImportError:
-        from utils.win32_process import ensure_game_window_resolution
-except Exception:
-    ensure_game_window_resolution = None
-
-try:
     from agent.custom.action.pinkpaw.pinkpaw_common import (
         _get_auto_resize_game_window,
         _parse_bool,
         _parse_custom_action_param,
+        ensure_game_window_resolution,
     )
 except ImportError:
     from .pinkpaw_common import (
         _get_auto_resize_game_window,
         _parse_bool,
         _parse_custom_action_param,
+        ensure_game_window_resolution,
     )
 
 try:
@@ -49,7 +43,6 @@ REWARD_OCR_DELAY_MS = 3000
 POST_REWARD_DELAY_MS = 7000
 DEFAULT_WIDTH = 1280
 DEFAULT_HEIGHT = 720
-DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
 
 
 class StopActionException(Exception):

--- a/agent/custom/action/pinkpaw/pinkpaw_core2.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core2.py
@@ -1,8 +1,17 @@
+import json
 from maa.agent.agent_server import AgentServer
 from maa.custom_action import CustomAction
 from maa.context import Context
 from maa.define import Status
 from datetime import datetime
+
+try:
+    try:
+        from agent.utils.win32_process import ensure_game_window_resolution
+    except ImportError:
+        from utils.win32_process import ensure_game_window_resolution
+except Exception:
+    ensure_game_window_resolution = None
 
 try:
     from agent.custom.action.pinkpaw.pinkpaw_reward_logger import notify_pinkpaw_reward
@@ -26,6 +35,10 @@ VK = {
 
 REWARD_OCR_DELAY_MS = 3000
 POST_REWARD_DELAY_MS = 7000
+DEFAULT_WIDTH = 1280
+DEFAULT_HEIGHT = 720
+DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
+AUTO_RESIZE_CONFIG_NODE = "PinkPawHeist_AutoResizeGameWindowConfig"
 
 
 class StopActionException(Exception):
@@ -43,6 +56,45 @@ def _is_hit(result) -> bool:
     if result.status.succeeded is False:
         return False
     return True
+
+
+def _parse_custom_action_param(argv: CustomAction.RunArg) -> dict:
+    value = getattr(argv, "custom_action_param", None)
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return value
+    try:
+        parsed = json.loads(value)
+    except Exception as exc:
+        print(
+            f"[PinkPawHeist/Core2] invalid custom_action_param: {value!r}, error: {exc}"
+        )
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _parse_bool(value, default=False) -> bool:
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
+    return bool(default)
+
+
+def _get_auto_resize_game_window(ctx: Context, default=DEFAULT_AUTO_RESIZE_GAME_WINDOW):
+    try:
+        node_data = ctx.get_node_data(AUTO_RESIZE_CONFIG_NODE) or {}
+    except Exception:
+        return bool(default)
+    attach = node_data.get("attach") if isinstance(node_data, dict) else None
+    if isinstance(attach, dict) and "auto_resize_game_window" in attach:
+        return _parse_bool(attach.get("auto_resize_game_window"), default)
+    return bool(default)
 
 
 class ActionHelper:
@@ -326,6 +378,14 @@ class PinkPawHeistScheme2Action(CustomAction):
     ) -> CustomAction.RunResult:
         ah = ActionHelper(context)
         try:
+            params = _parse_custom_action_param(argv)
+            auto_resize_default = _get_auto_resize_game_window(context)
+            auto_resize = _parse_bool(
+                params.get("auto_resize_game_window"),
+                auto_resize_default,
+            )
+            if auto_resize and ensure_game_window_resolution:
+                ensure_game_window_resolution(DEFAULT_WIDTH, DEFAULT_HEIGHT)
             current_ctrl = ah.ctx.tasker.controller
             for _ in range(3):
                 ah.click_key("1")

--- a/agent/custom/action/pinkpaw/pinkpaw_core3.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core3.py
@@ -3297,6 +3297,8 @@ class PinkPawHeistCore3Path:
         self.sleep(0.10)
         self.send_key_down("w")
         self.wait_and_interact(direction="w", is_lock=True, time_out=5.4)
+        if self.find_interac():
+            self.wait_and_interact(direction="w", is_lock=True, time_out=5.4)
         self.sleep(0.01)
         self.send_key_down("w")
         self.sleep(0.38)

--- a/agent/custom/action/pinkpaw/pinkpaw_core3.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core3.py
@@ -3355,7 +3355,7 @@ class PinkPawHeistCore3Path:
         self.send_key("lshift", down_time=0.24)
         self.sleep(0.42)
         self.send_key_down("d")
-        self.sleep(0.43)
+        self.sleep(0.40)
         self.send_key_up("d")
         self.sleep(0.70)
         self.send_key_up("w")

--- a/agent/custom/action/pinkpaw/pinkpaw_core3.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core3.py
@@ -23,24 +23,18 @@ except ImportError:
     cv2 = None
 
 try:
-    try:
-        from agent.utils.win32_process import ensure_game_window_resolution
-    except ImportError:
-        from utils.win32_process import ensure_game_window_resolution
-except Exception:
-    ensure_game_window_resolution = None
-
-try:
     from agent.custom.action.pinkpaw.pinkpaw_common import (
         _get_auto_resize_game_window,
         _parse_bool,
         _parse_custom_action_param,
+        ensure_game_window_resolution,
     )
 except ImportError:
     from .pinkpaw_common import (
         _get_auto_resize_game_window,
         _parse_bool,
         _parse_custom_action_param,
+        ensure_game_window_resolution,
     )
 
 try:
@@ -80,7 +74,6 @@ DEFAULT_HEIGHT = 720
 DEFAULT_ROUTE_TIMING_SCALE = 1.0
 DEFAULT_INTERACTION_PAUSE = 0.7
 DEFAULT_DIRECT_INPUT = True
-DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
 MIN_ROUTE_TIMING_SCALE = 0.25
 MAX_ROUTE_TIMING_SCALE = 1.2
 MIN_INTERACTION_PAUSE = 0.0

--- a/agent/custom/action/pinkpaw/pinkpaw_core3.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core3.py
@@ -24,6 +24,14 @@ except ImportError:
     cv2 = None
 
 try:
+    try:
+        from agent.utils.win32_process import ensure_game_window_resolution
+    except ImportError:
+        from utils.win32_process import ensure_game_window_resolution
+except Exception:
+    ensure_game_window_resolution = None
+
+try:
     from agent.custom.action.pinkpaw.pinkpaw_reward_logger import notify_pinkpaw_reward
 except ImportError:
     from .pinkpaw_reward_logger import notify_pinkpaw_reward
@@ -60,6 +68,8 @@ DEFAULT_HEIGHT = 720
 DEFAULT_ROUTE_TIMING_SCALE = 1.0
 DEFAULT_INTERACTION_PAUSE = 0.7
 DEFAULT_DIRECT_INPUT = True
+DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
+AUTO_RESIZE_CONFIG_NODE = "PinkPawHeist_AutoResizeGameWindowConfig"
 MIN_ROUTE_TIMING_SCALE = 0.25
 MAX_ROUTE_TIMING_SCALE = 1.2
 MIN_INTERACTION_PAUSE = 0.0
@@ -254,6 +264,17 @@ def _parse_bool(value, default=False) -> bool:
         return bool(value)
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
+    return bool(default)
+
+
+def _get_auto_resize_game_window(ctx: Context, default=DEFAULT_AUTO_RESIZE_GAME_WINDOW):
+    try:
+        node_data = ctx.get_node_data(AUTO_RESIZE_CONFIG_NODE) or {}
+    except Exception:
+        return bool(default)
+    attach = node_data.get("attach") if isinstance(node_data, dict) else None
+    if isinstance(attach, dict) and "auto_resize_game_window" in attach:
+        return _parse_bool(attach.get("auto_resize_game_window"), default)
     return bool(default)
 
 
@@ -817,6 +838,11 @@ class PinkPawHeistCore3Path:
         params = params or {}
         self.ctx = ctx
         direct_input = _parse_bool(params.get("direct_input"), DEFAULT_DIRECT_INPUT)
+        auto_resize_default = _get_auto_resize_game_window(ctx)
+        self.auto_resize_game_window = _parse_bool(
+            params.get("auto_resize_game_window"),
+            auto_resize_default,
+        )
         self.ah = Core3ActionHelper(ctx, direct_input=direct_input)
         self.exit_state = {1: False, 2: False, 3: False, 4: False}
         self.avoid_methods = [self.AVOID_METHOD_DASH, self.AVOID_METHOD_ATTACK]
@@ -3763,6 +3789,8 @@ class PinkPawHeistScheme3Action(CustomAction):
                 )
         path = PinkPawHeistCore3Path(context, params=params)
         try:
+            if path.auto_resize_game_window and ensure_game_window_resolution:
+                ensure_game_window_resolution(DEFAULT_WIDTH, DEFAULT_HEIGHT)
             input_mode = "direct" if path.ah.direct_input.available else "maa"
             path.log_round_info(
                 f"Start, method {path.config[path.CONF_AVOID_MTH]}, timing x{path.route_timing_scale:.2f}, input {input_mode}"

--- a/agent/custom/action/pinkpaw/pinkpaw_core3.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_core3.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ctypes
-import json
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +29,19 @@ try:
         from utils.win32_process import ensure_game_window_resolution
 except Exception:
     ensure_game_window_resolution = None
+
+try:
+    from agent.custom.action.pinkpaw.pinkpaw_common import (
+        _get_auto_resize_game_window,
+        _parse_bool,
+        _parse_custom_action_param,
+    )
+except ImportError:
+    from .pinkpaw_common import (
+        _get_auto_resize_game_window,
+        _parse_bool,
+        _parse_custom_action_param,
+    )
 
 try:
     from agent.custom.action.pinkpaw.pinkpaw_reward_logger import notify_pinkpaw_reward
@@ -69,7 +81,6 @@ DEFAULT_ROUTE_TIMING_SCALE = 1.0
 DEFAULT_INTERACTION_PAUSE = 0.7
 DEFAULT_DIRECT_INPUT = True
 DEFAULT_AUTO_RESIZE_GAME_WINDOW = True
-AUTO_RESIZE_CONFIG_NODE = "PinkPawHeist_AutoResizeGameWindowConfig"
 MIN_ROUTE_TIMING_SCALE = 0.25
 MAX_ROUTE_TIMING_SCALE = 1.2
 MIN_INTERACTION_PAUSE = 0.0
@@ -228,23 +239,6 @@ def _normalize_key_sequence(value) -> list[str]:
     return result
 
 
-def _parse_custom_action_param(argv: CustomAction.RunArg) -> dict:
-    """解析节点传入的 custom_action_param，非法或空值时返回空配置。"""
-    value = getattr(argv, "custom_action_param", None)
-    if not value:
-        return {}
-    if isinstance(value, dict):
-        return value
-    try:
-        parsed = json.loads(value)
-    except Exception as exc:
-        print(
-            f"[PinkPawHeist/Core3] invalid custom_action_param: {value!r}, error: {exc}"
-        )
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
-
-
 def _parse_timing_scale(value) -> float:
     """解析路线时间微调倍率，并限制在允许范围内。"""
     try:
@@ -252,30 +246,6 @@ def _parse_timing_scale(value) -> float:
     except (TypeError, ValueError):
         scale = DEFAULT_ROUTE_TIMING_SCALE
     return max(MIN_ROUTE_TIMING_SCALE, min(MAX_ROUTE_TIMING_SCALE, scale))
-
-
-def _parse_bool(value, default=False) -> bool:
-    """把开关配置解析为布尔值，兼容字符串、数字和 bool。"""
-    if value is None:
-        return bool(default)
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
-    return bool(default)
-
-
-def _get_auto_resize_game_window(ctx: Context, default=DEFAULT_AUTO_RESIZE_GAME_WINDOW):
-    try:
-        node_data = ctx.get_node_data(AUTO_RESIZE_CONFIG_NODE) or {}
-    except Exception:
-        return bool(default)
-    attach = node_data.get("attach") if isinstance(node_data, dict) else None
-    if isinstance(attach, dict) and "auto_resize_game_window" in attach:
-        return _parse_bool(attach.get("auto_resize_game_window"), default)
-    return bool(default)
 
 
 def _parse_interaction_pause(value) -> float:
@@ -3776,7 +3746,7 @@ class PinkPawHeistScheme3Action(CustomAction):
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
         """MAA 自定义动作入口：创建 Core3 路线对象，执行路线，并统一处理停止、提前撤离和异常恢复。"""
-        params = _parse_custom_action_param(argv)
+        params = _parse_custom_action_param(argv, log_prefix="[PinkPawHeist/Core3]")
         if PinkPawHeistCore3Path.CONF_AVOID_MTH not in params:
             node_name = getattr(argv, "node_name", "")
             if node_name.endswith("_Attack"):

--- a/agent/custom/action/pinkpaw/pinkpaw_entrance_recovery.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_entrance_recovery.py
@@ -13,6 +13,7 @@ try:
         DEFAULT_WIDTH,
         PinkPawHeistCore3Path,
         TaskerStoppedException,
+        ensure_game_window_resolution,
         _parse_custom_action_param,
         _is_hit,
     )
@@ -23,6 +24,7 @@ except ImportError:
         DEFAULT_WIDTH,
         PinkPawHeistCore3Path,
         TaskerStoppedException,
+        ensure_game_window_resolution,
         _parse_custom_action_param,
         _is_hit,
     )
@@ -431,6 +433,8 @@ class PinkPawHeistReturnToEntranceAction(CustomAction):
         params = _parse_custom_action_param(argv)
         path = PinkPawHeistEntranceRecoveryPath(context, params=params)
         try:
+            if path.auto_resize_game_window and ensure_game_window_resolution:
+                ensure_game_window_resolution(DEFAULT_WIDTH, DEFAULT_HEIGHT)
             path.recover_to_heist_entrance()
             return CustomAction.RunResult(success=True)
         except TaskerStoppedException as exc:
@@ -454,6 +458,8 @@ class PinkPawHeistFindXiaoZhiAction(CustomAction):
         params = _parse_custom_action_param(argv)
         path = PinkPawHeistEntranceRecoveryPath(context, params=params)
         try:
+            if path.auto_resize_game_window and ensure_game_window_resolution:
+                ensure_game_window_resolution(DEFAULT_WIDTH, DEFAULT_HEIGHT)
             path.log_round_info("开始寻找小吱")
             path.ah.run_task("SceneAnyEnterWorld")
             if path._has_xiaozhi_prompt(time_out=10.0):

--- a/agent/custom/action/pinkpaw/pinkpaw_entrance_recovery.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_entrance_recovery.py
@@ -13,7 +13,6 @@ try:
         DEFAULT_WIDTH,
         PinkPawHeistCore3Path,
         TaskerStoppedException,
-        ensure_game_window_resolution,
         _is_hit,
     )
 except ImportError:
@@ -23,14 +22,16 @@ except ImportError:
         DEFAULT_WIDTH,
         PinkPawHeistCore3Path,
         TaskerStoppedException,
-        ensure_game_window_resolution,
         _is_hit,
     )
 
 try:
-    from agent.custom.action.pinkpaw.pinkpaw_common import _parse_custom_action_param
+    from agent.custom.action.pinkpaw.pinkpaw_common import (
+        _parse_custom_action_param,
+        ensure_game_window_resolution,
+    )
 except ImportError:
-    from .pinkpaw_common import _parse_custom_action_param
+    from .pinkpaw_common import _parse_custom_action_param, ensure_game_window_resolution
 
 
 RECOVERY_ENTRANCE_ROUTE_MINT = [

--- a/agent/custom/action/pinkpaw/pinkpaw_entrance_recovery.py
+++ b/agent/custom/action/pinkpaw/pinkpaw_entrance_recovery.py
@@ -14,7 +14,6 @@ try:
         PinkPawHeistCore3Path,
         TaskerStoppedException,
         ensure_game_window_resolution,
-        _parse_custom_action_param,
         _is_hit,
     )
 except ImportError:
@@ -25,9 +24,13 @@ except ImportError:
         PinkPawHeistCore3Path,
         TaskerStoppedException,
         ensure_game_window_resolution,
-        _parse_custom_action_param,
         _is_hit,
     )
+
+try:
+    from agent.custom.action.pinkpaw.pinkpaw_common import _parse_custom_action_param
+except ImportError:
+    from .pinkpaw_common import _parse_custom_action_param
 
 
 RECOVERY_ENTRANCE_ROUTE_MINT = [
@@ -430,7 +433,7 @@ class PinkPawHeistReturnToEntranceAction(CustomAction):
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
         """找不到小吱时的恢复入口：传送到粉爪大塔并跑回小吱位置。"""
-        params = _parse_custom_action_param(argv)
+        params = _parse_custom_action_param(argv, log_prefix="[PinkPawHeist/Recovery]")
         path = PinkPawHeistEntranceRecoveryPath(context, params=params)
         try:
             if path.auto_resize_game_window and ensure_game_window_resolution:
@@ -455,7 +458,7 @@ class PinkPawHeistFindXiaoZhiAction(CustomAction):
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
         """寻找小吱入口；找不到时先恢复到粉爪入口，再重新确认交互提示。"""
-        params = _parse_custom_action_param(argv)
+        params = _parse_custom_action_param(argv, log_prefix="[PinkPawHeist/Recovery]")
         path = PinkPawHeistEntranceRecoveryPath(context, params=params)
         try:
             if path.auto_resize_game_window and ensure_game_window_resolution:

--- a/agent/utils/win32_process.py
+++ b/agent/utils/win32_process.py
@@ -73,7 +73,7 @@ WS_POPUP = 0x80000000
 SM_CXSCREEN = 0
 SM_CYSCREEN = 1
 SWP_NOSIZE = 0x0001
-SWP_NOREPOSITION = 0x0002
+SWP_NOREPOSITION = 0x0200
 SWP_NOZORDER = 0x0004
 SWP_NOACTIVATE = 0x0010
 SWP_NOMOVE = 0x0002
@@ -315,7 +315,7 @@ def resize_window(hwnd, width, height, center=True):
         return False
     width = int(width)
     height = int(height)
-    flags = SWP_SHOWWINDOW | SWP_NOZORDER | SWP_NOREPOSITION
+    flags = SWP_SHOWWINDOW | SWP_NOZORDER | SWP_NOMOVE
     if not user32.SetWindowPos(hwnd, None, 0, 0, width, height, flags):
         return False
     kernel32.Sleep(10)
@@ -418,9 +418,19 @@ def ensure_process_client_size(
     center=True,
     tolerance=2,
     settle_ms=300,
+    hwnd_class=None,
+    require_title=False,
+    selected_hwnd=0,
+    last_hwnd=0,
 ):
     """Find a process window and resize its client area to the target size."""
-    hwnd = find_window_by_process(process_name)
+    hwnd = find_window_by_process(
+        process_name,
+        hwnd_class=hwnd_class,
+        require_title=require_title,
+        selected_hwnd=selected_hwnd,
+        last_hwnd=last_hwnd,
+    )
     if not hwnd:
         return {
             "success": False,

--- a/agent/utils/win32_process.py
+++ b/agent/utils/win32_process.py
@@ -1,16 +1,89 @@
 import ctypes
+import os
+import re
 from ctypes import wintypes
 
 user32 = ctypes.windll.user32
 kernel32 = ctypes.windll.kernel32
+
+user32.GetWindowRect.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.RECT)]
+user32.GetWindowRect.restype = wintypes.BOOL
+user32.GetClientRect.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.RECT)]
+user32.GetClientRect.restype = wintypes.BOOL
+user32.GetWindowThreadProcessId.argtypes = [
+    wintypes.HWND,
+    ctypes.POINTER(wintypes.DWORD),
+]
+user32.GetWindowThreadProcessId.restype = wintypes.DWORD
+user32.GetWindowTextLengthW.argtypes = [wintypes.HWND]
+user32.GetWindowTextLengthW.restype = ctypes.c_int
+user32.GetWindowTextW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+user32.GetWindowTextW.restype = ctypes.c_int
+user32.GetClassNameW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+user32.GetClassNameW.restype = ctypes.c_int
+user32.GetWindowLongW.argtypes = [wintypes.HWND, ctypes.c_int]
+user32.GetWindowLongW.restype = wintypes.LONG
+user32.SetWindowLongW.argtypes = [wintypes.HWND, ctypes.c_int, wintypes.LONG]
+user32.SetWindowLongW.restype = wintypes.LONG
+user32.SetWindowPos.argtypes = [
+    wintypes.HWND,
+    wintypes.HWND,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    wintypes.UINT,
+]
+user32.SetWindowPos.restype = wintypes.BOOL
+user32.MonitorFromWindow.argtypes = [wintypes.HWND, wintypes.DWORD]
+user32.MonitorFromWindow.restype = wintypes.HANDLE
+user32.GetMonitorInfoW.argtypes = [wintypes.HANDLE, ctypes.c_void_p]
+user32.GetMonitorInfoW.restype = wintypes.BOOL
+user32.IsIconic.argtypes = [wintypes.HWND]
+user32.IsIconic.restype = wintypes.BOOL
+user32.IsZoomed.argtypes = [wintypes.HWND]
+user32.IsZoomed.restype = wintypes.BOOL
+user32.IsWindow.argtypes = [wintypes.HWND]
+user32.IsWindow.restype = wintypes.BOOL
+user32.IsWindowEnabled.argtypes = [wintypes.HWND]
+user32.IsWindowEnabled.restype = wintypes.BOOL
+user32.IsWindowVisible.argtypes = [wintypes.HWND]
+user32.IsWindowVisible.restype = wintypes.BOOL
+user32.ShowWindow.argtypes = [wintypes.HWND, ctypes.c_int]
+user32.ShowWindow.restype = wintypes.BOOL
+user32.GetSystemMetrics.argtypes = [ctypes.c_int]
+user32.GetSystemMetrics.restype = ctypes.c_int
+kernel32.Sleep.argtypes = [wintypes.DWORD]
 
 # 使进程感知 DPI，避免 GetClientRect 返回缩放后的虚拟坐标
 # 150% 缩放时未设置此项会导致返回值只有实际分辨率的 2/3
 user32.SetProcessDPIAware()
 
 WNDENUMPROC = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+user32.EnumWindows.argtypes = [WNDENUMPROC, wintypes.LPARAM]
+user32.EnumWindows.restype = wintypes.BOOL
 
 TH32CS_SNAPPROCESS = 0x00000002
+DEFAULT_GAME_PROCESS_NAME = "HTGame.exe"
+DEFAULT_WINDOW_RESIZE_SETTLE_MS = 300
+SW_RESTORE = 9
+GWL_STYLE = -16
+WS_CAPTION = 0x00C00000
+WS_POPUP = 0x80000000
+SM_CXSCREEN = 0
+SM_CYSCREEN = 1
+SWP_NOSIZE = 0x0001
+SWP_NOREPOSITION = 0x0002
+SWP_NOZORDER = 0x0004
+SWP_NOACTIVATE = 0x0010
+SWP_NOMOVE = 0x0002
+SWP_FRAMECHANGED = 0x0020
+SWP_SHOWWINDOW = 0x0040
+MONITOR_DEFAULTTONEAREST = 0x00000002
+
+
+def _log(message):
+    print(f"[Win32Process] {message}")
 
 
 class PROCESSENTRY32W(ctypes.Structure):
@@ -28,7 +101,32 @@ class PROCESSENTRY32W(ctypes.Structure):
     ]
 
 
+class MONITORINFO(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("rcMonitor", wintypes.RECT),
+        ("rcWork", wintypes.RECT),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
+
+def _normalize_process_names(process_name):
+    if isinstance(process_name, str):
+        items = [process_name]
+    else:
+        items = list(process_name or [])
+    names = []
+    for item in items:
+        name = os.path.basename(str(item)).strip().lower()
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
 def get_pids_by_name(process_name):
+    process_names = set(_normalize_process_names(process_name))
+    if not process_names:
+        return []
     snapshot = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
     if snapshot == -1:
         return []
@@ -37,7 +135,7 @@ def get_pids_by_name(process_name):
     pids = []
     if kernel32.Process32FirstW(snapshot, ctypes.byref(entry)):
         while True:
-            if entry.szExeFile.lower() == process_name.lower():
+            if entry.szExeFile.lower() in process_names:
                 pids.append(entry.th32ProcessID)
             if not kernel32.Process32NextW(snapshot, ctypes.byref(entry)):
                 break
@@ -45,24 +143,111 @@ def get_pids_by_name(process_name):
     return pids
 
 
-def find_window_by_process(process_name):
+def get_window_text(hwnd):
+    length = user32.GetWindowTextLengthW(hwnd)
+    if length <= 0:
+        return ""
+    buffer = ctypes.create_unicode_buffer(length + 1)
+    user32.GetWindowTextW(hwnd, buffer, length + 1)
+    return buffer.value
+
+
+def get_class_name(hwnd):
+    buffer = ctypes.create_unicode_buffer(256)
+    user32.GetClassNameW(hwnd, buffer, len(buffer))
+    return buffer.value
+
+
+def _match_class_name(class_name, patterns):
+    if patterns is None:
+        return True
+    if isinstance(patterns, str):
+        patterns = [patterns]
+    for pattern in patterns:
+        if isinstance(pattern, str):
+            if class_name == pattern:
+                return True
+        elif re.search(pattern, class_name):
+            return True
+    return False
+
+
+def find_windows_by_process(process_name, hwnd_class=None, require_title=False):
     pids = get_pids_by_name(process_name)
     if not pids:
-        return None
+        return []
     pid_set = set(pids)
     results = []
 
     def callback(hwnd, _lparam):
+        if not user32.IsWindow(hwnd) or not user32.IsWindowEnabled(hwnd):
+            return True
         if not user32.IsWindowVisible(hwnd):
             return True
         pid = wintypes.DWORD()
         user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
-        if pid.value in pid_set:
-            results.append(hwnd)
+        if pid.value not in pid_set:
+            return True
+        class_name = get_class_name(hwnd)
+        if not _match_class_name(class_name, hwnd_class):
+            return True
+        title = get_window_text(hwnd)
+        if require_title and not title:
+            return True
+        client_size = get_client_size(hwnd)
+        if client_size is None or client_size[0] <= 10 or client_size[1] <= 10:
+            return True
+        window_rect = get_window_rect(hwnd)
+        if window_rect is None:
+            return True
+        results.append(
+            {
+                "hwnd": hwnd,
+                "client_size": client_size,
+                "client_area": client_size[0] * client_size[1],
+                "window_rect": window_rect,
+                "title": title,
+                "class_name": class_name,
+                "order": len(results),
+            }
+        )
         return True
 
-    user32.EnumWindows(WNDENUMPROC(callback), 0)
-    return results[0] if results else None
+    callback_ref = WNDENUMPROC(callback)
+    user32.EnumWindows(callback_ref, 0)
+    return results
+
+
+def find_window_by_process(
+    process_name,
+    hwnd_class=None,
+    require_title=False,
+    selected_hwnd=0,
+    last_hwnd=0,
+):
+    windows = find_windows_by_process(
+        process_name,
+        hwnd_class=hwnd_class,
+        require_title=require_title,
+    )
+    if not windows:
+        return None
+
+    selected = next(
+        (item for item in windows if selected_hwnd and item["hwnd"] == selected_hwnd),
+        None,
+    )
+    biggest = max(windows, key=lambda item: item["client_area"])
+    if selected is not None:
+        return selected["hwnd"]
+
+    last = next(
+        (item for item in windows if last_hwnd and item["hwnd"] == last_hwnd),
+        None,
+    )
+    if last is not None and biggest["client_area"] <= last["client_area"] * 1.1:
+        return last["hwnd"]
+    return biggest["hwnd"]
 
 
 def get_client_size(hwnd):
@@ -70,3 +255,223 @@ def get_client_size(hwnd):
     if not user32.GetClientRect(hwnd, ctypes.byref(rect)):
         return None
     return rect.right - rect.left, rect.bottom - rect.top
+
+
+def get_window_rect(hwnd):
+    rect = wintypes.RECT()
+    if not user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+        return None
+    return rect.left, rect.top, rect.right, rect.bottom
+
+
+def _get_monitor_work_area(hwnd):
+    monitor = user32.MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)
+    info = MONITORINFO()
+    info.cbSize = ctypes.sizeof(MONITORINFO)
+    if not monitor or not user32.GetMonitorInfoW(monitor, ctypes.byref(info)):
+        return None
+    rect = info.rcWork
+    return rect.left, rect.top, rect.right, rect.bottom
+
+
+def show_title_bar(hwnd):
+    """make sure the target window has a normal title bar."""
+    try:
+        current_style = user32.GetWindowLongW(hwnd, GWL_STYLE)
+        if current_style & WS_CAPTION:
+            return True
+        new_style = (int(current_style) | WS_CAPTION) & ~WS_POPUP
+        user32.SetWindowLongW(hwnd, GWL_STYLE, new_style)
+        user32.SetWindowPos(
+            hwnd,
+            None,
+            0,
+            0,
+            0,
+            0,
+            SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW,
+        )
+        kernel32.Sleep(10)
+        return bool(user32.GetWindowLongW(hwnd, GWL_STYLE) & WS_CAPTION)
+    except Exception:
+        return False
+
+
+def resize_window(hwnd, width, height, center=True):
+    """Resize the outer window and center it, following OK-NTE's sequence."""
+    if not hwnd:
+        return False
+    width = int(width)
+    height = int(height)
+    flags = SWP_SHOWWINDOW | SWP_NOZORDER | SWP_NOREPOSITION
+    if not user32.SetWindowPos(hwnd, None, 0, 0, width, height, flags):
+        return False
+    kernel32.Sleep(10)
+
+    expected_left = None
+    expected_top = None
+    if center:
+        rect = get_window_rect(hwnd)
+        if rect is None:
+            return False
+        left, top, right, bottom = rect
+        window_width = right - left
+        window_height = bottom - top
+        screen_width = user32.GetSystemMetrics(SM_CXSCREEN)
+        screen_height = user32.GetSystemMetrics(SM_CYSCREEN)
+        expected_left = (screen_width - window_width) // 2
+        expected_top = (screen_height - window_height) // 2
+        if not user32.SetWindowPos(
+            hwnd,
+            None,
+            expected_left,
+            expected_top,
+            0,
+            0,
+            SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW,
+        ):
+            return False
+
+    for _ in range(50):
+        rect = get_window_rect(hwnd)
+        if rect is None:
+            return False
+        left, top, right, bottom = rect
+        current_width = right - left
+        current_height = bottom - top
+        size_ok = current_width == width and current_height == height
+        pos_ok = not center or (left == expected_left and top == expected_top)
+        if size_ok and pos_ok:
+            break
+        kernel32.Sleep(100)
+    kernel32.Sleep(500)
+    return True
+
+
+def resize_client_area(hwnd, width, height, center=True, tolerance=2):
+    """Resize a window so its client area matches the target size."""
+    if not hwnd:
+        return False
+    target_width = int(width)
+    target_height = int(height)
+    if user32.IsIconic(hwnd) or user32.IsZoomed(hwnd):
+        user32.ShowWindow(hwnd, SW_RESTORE)
+        kernel32.Sleep(100)
+    show_title_bar(hwnd)
+
+    current_client = get_client_size(hwnd)
+    current_rect = get_window_rect(hwnd)
+    if current_client is None or current_rect is None:
+        return False
+    if (
+        abs(current_client[0] - target_width) <= tolerance
+        and abs(current_client[1] - target_height) <= tolerance
+    ):
+        return True
+
+    left, top, right, bottom = current_rect
+    window_width = right - left
+    window_height = bottom - top
+    border = max(0, window_width - current_client[0])
+    title_height = max(0, window_height - current_client[1])
+    resized_width = target_width + border
+    resized_height = target_height + title_height
+    screen_width = user32.GetSystemMetrics(SM_CXSCREEN)
+    screen_height = user32.GetSystemMetrics(SM_CYSCREEN)
+    if screen_width < resized_width or screen_height < resized_height:
+        return False
+
+    if not resize_window(hwnd, resized_width, resized_height, center=center):
+        return False
+
+    for _ in range(20):
+        current_client = get_client_size(hwnd)
+        if current_client is not None and (
+            abs(current_client[0] - target_width) <= tolerance
+            and abs(current_client[1] - target_height) <= tolerance
+        ):
+            return True
+        kernel32.Sleep(50)
+    return False
+
+
+def ensure_process_client_size(
+    process_name,
+    width,
+    height,
+    center=True,
+    tolerance=2,
+    settle_ms=300,
+):
+    """Find a process window and resize its client area to the target size."""
+    hwnd = find_window_by_process(process_name)
+    if not hwnd:
+        return {
+            "success": False,
+            "reason": "window_not_found",
+            "hwnd": None,
+            "before": None,
+            "after": None,
+        }
+
+    target = (int(width), int(height))
+    before = get_client_size(hwnd)
+    if before is None:
+        return {
+            "success": False,
+            "reason": "client_size_unavailable",
+            "hwnd": hwnd,
+            "before": None,
+            "after": None,
+        }
+
+    if (
+        abs(before[0] - target[0]) <= tolerance
+        and abs(before[1] - target[1]) <= tolerance
+    ):
+        return {
+            "success": True,
+            "reason": "already_matched",
+            "hwnd": hwnd,
+            "before": before,
+            "after": before,
+        }
+
+    resized = resize_client_area(
+        hwnd,
+        target[0],
+        target[1],
+        center=center,
+        tolerance=tolerance,
+    )
+    if resized and settle_ms:
+        kernel32.Sleep(int(settle_ms))
+    after = get_client_size(hwnd)
+    if resized:
+        _log(
+            f"game window resolution {before[0]}x{before[1]} -> {target[0]}x{target[1]}"
+        )
+    return {
+        "success": bool(resized),
+        "reason": "resized" if resized else "resize_failed",
+        "hwnd": hwnd,
+        "before": before,
+        "after": after,
+    }
+
+
+def ensure_game_window_resolution(
+    width,
+    height,
+    process_name=DEFAULT_GAME_PROCESS_NAME,
+    settle_ms=DEFAULT_WINDOW_RESIZE_SETTLE_MS,
+    **kwargs,
+):
+    """Resize the game window client area to the target resolution."""
+    return ensure_process_client_size(
+        process_name,
+        width,
+        height,
+        settle_ms=settle_ms,
+        **kwargs,
+    )

--- a/agent/utils/win32_process.py
+++ b/agent/utils/win32_process.py
@@ -274,6 +274,18 @@ def _get_monitor_work_area(hwnd):
     return rect.left, rect.top, rect.right, rect.bottom
 
 
+def _get_window_work_area(hwnd):
+    work_area = _get_monitor_work_area(hwnd)
+    if work_area is not None:
+        return work_area
+    return (
+        0,
+        0,
+        user32.GetSystemMetrics(SM_CXSCREEN),
+        user32.GetSystemMetrics(SM_CYSCREEN),
+    )
+
+
 def show_title_bar(hwnd):
     """make sure the target window has a normal title bar."""
     try:
@@ -317,10 +329,13 @@ def resize_window(hwnd, width, height, center=True):
         left, top, right, bottom = rect
         window_width = right - left
         window_height = bottom - top
-        screen_width = user32.GetSystemMetrics(SM_CXSCREEN)
-        screen_height = user32.GetSystemMetrics(SM_CYSCREEN)
-        expected_left = (screen_width - window_width) // 2
-        expected_top = (screen_height - window_height) // 2
+        work_left, work_top, work_right, work_bottom = _get_window_work_area(hwnd)
+        work_width = work_right - work_left
+        work_height = work_bottom - work_top
+        if work_width < window_width or work_height < window_height:
+            return False
+        expected_left = work_left + (work_width - window_width) // 2
+        expected_top = work_top + (work_height - window_height) // 2
         if not user32.SetWindowPos(
             hwnd,
             None,
@@ -376,9 +391,10 @@ def resize_client_area(hwnd, width, height, center=True, tolerance=2):
     title_height = max(0, window_height - current_client[1])
     resized_width = target_width + border
     resized_height = target_height + title_height
-    screen_width = user32.GetSystemMetrics(SM_CXSCREEN)
-    screen_height = user32.GetSystemMetrics(SM_CYSCREEN)
-    if screen_width < resized_width or screen_height < resized_height:
+    work_left, work_top, work_right, work_bottom = _get_window_work_area(hwnd)
+    work_width = work_right - work_left
+    work_height = work_bottom - work_top
+    if work_width < resized_width or work_height < resized_height:
         return False
 
     if not resize_window(hwnd, resized_width, resized_height, center=center):

--- a/assets/resource/base/pipeline/Common/ResizeGameWindow.json
+++ b/assets/resource/base/pipeline/Common/ResizeGameWindow.json
@@ -1,0 +1,17 @@
+{
+    "ResizeGameWindow": {
+        "desc": "调整游戏窗口客户区分辨率，默认 1280x720",
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "resize_game_window"
+            }
+        },
+        "rate_limit": 0,
+        "pre_delay": 0,
+        "post_delay": 0
+    }
+}

--- a/assets/resource/base/pipeline/PinkPawHeist.json
+++ b/assets/resource/base/pipeline/PinkPawHeist.json
@@ -16,6 +16,12 @@
             }
         }
     },
+    "PinkPawHeist_AutoResizeGameWindowConfig": {
+        "enabled": false,
+        "attach": {
+            "auto_resize_game_window": true
+        }
+    },
     "PinkPawHeist_Loop": {
         "recognition": {
             "type": "DirectHit"

--- a/assets/resource/tasks/PinkPawHeist.json
+++ b/assets/resource/tasks/PinkPawHeist.json
@@ -58,7 +58,7 @@
         },
         "PinkPawHeist_AutoResizeGameWindow": {
             "type": "switch",
-            "label": "自动设置游戏分辨率",
+            "label": "自动设置游戏分辨率到1280x720，如关闭请确保游戏分辨率为1280x720，否则可能会导致识图失败",
             "default_case": "Yes",
             "cases": [
                 {

--- a/assets/resource/tasks/PinkPawHeist.json
+++ b/assets/resource/tasks/PinkPawHeist.json
@@ -7,7 +7,8 @@
             "description": "自动刷取粉爪大劫案，需要<span style='color:red'>“桌面端-前台”</span>控制器。",
             "option": [
                 "PinkPawHeist_Loop",
-                "PinkPawHeist_Scheme"
+                "PinkPawHeist_Scheme",
+                "PinkPawHeist_AutoResizeGameWindow"
             ],
             "controller": [
                 "Win32-Front"
@@ -54,6 +55,28 @@
                     "max_hit": "{count}"
                 }
             }
+        },
+        "PinkPawHeist_AutoResizeGameWindow": {
+            "type": "switch",
+            "label": "自动设置游戏分辨率",
+            "default_case": "Yes",
+            "cases": [
+                {
+                    "name": "Yes",
+                    "label": "开启"
+                },
+                {
+                    "name": "No",
+                    "label": "关闭",
+                    "pipeline_override": {
+                        "PinkPawHeist_AutoResizeGameWindowConfig": {
+                            "attach": {
+                                "auto_resize_game_window": false
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "PinkPawHeist_Scheme": {
             "type": "select",

--- a/assets/resource/tasks/PinkPawHeist.json
+++ b/assets/resource/tasks/PinkPawHeist.json
@@ -194,7 +194,7 @@
         "PinkPawHeist_Scheme_Core3_desc": {
             "type": "input",
             "label": "方案三说明",
-            "description": "<span style='color:orange'>改编自 ok-nte 粉爪路径2，请设置画质到性能档位，帧率设置60~120帧，关闭设置里的移动镜头修正！打开按下锁定镜头回正！到小吱旁边启动！包里要至少有一个复活药！</span><br><span style='color:green'>路线说明：</span>使用 ok 路径2，按固定站位配队；只需要在“方案三配队”里选择你实际使用的站位组合。",
+            "description": "<span style='color:orange'>改编自 ok-nte 粉爪路径2，请设置画质到性能档位，帧率设置60~120帧，关闭设置里的移动镜头修正！打开按下锁定镜头回正！锁定方式改为角色朝向优先！到小吱旁边启动！包里要至少有一个复活药！</span><br><span style='color:green'>路线说明：</span>使用 ok 路径2，按固定站位配队；只需要在“方案三配队”里选择你实际使用的站位组合。",
             "inputs": []
         },
         "PinkPawHeist_Scheme_Core3_AvoidMethod": {


### PR DESCRIPTION
## 变更内容

- 新增 Win32 游戏窗口客户区分辨率调整能力，默认将游戏客户区调整为 `1280x720`
- 粉爪方案 1 / 2 / 3 以及入口恢复流程启动前接入自动分辨率设置
- 在粉爪任务配置中新增“自动设置游戏分辨率”开关，默认开启，可一键关闭
- 优化窗口匹配逻辑，优先匹配可见、可用、客户区有效且面积最大的游戏窗口
- README 鸣谢中补充 OK-NTE 参考来源

## 验证

- 通过 `python -m py_compile`
- 通过相关 JSON/JSONC 配置解析检查
- 通过 `git diff --check`

## 由 Sourcery 提供的摘要

为 PinkPaw 抢劫（heist）动作添加自动 Windows 游戏窗口分辨率管理，并重构共享的 PinkPaw 配置解析逻辑。

新功能：
- 引入 Win32 工具，用于定位并将某个进程窗口的客户区调整到目标分辨率，并提供针对游戏窗口的专用辅助函数。
- 使 PinkPaw 抢劫方案 1、2、3 以及入口恢复流程在运行前可自动设置游戏窗口分辨率，默认使用 1280x720。
- 为 PinkPaw 任务新增可配置的 `auto_resize_game_window` 开关，默认值由流水线节点（pipeline node）驱动，并可在每次运行时进行覆盖。

增强内容：
- 通过枚举某个进程的候选窗口，并根据可见性、可用性、类名/标题过滤以及客户区大小来选择最合适的窗口，从而改进游戏窗口选择逻辑。
- 将通用的 PinkPaw 参数解析和布尔值处理提取到共享模块中，以减少重复代码。
- 在 README 的致谢部分中添加 OK-NTE。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 PinkPaw 抢劫动作添加自动 Windows 游戏窗口分辨率管理和共享配置工具，并公开一个通用的 resize-game-window 自定义动作。

新功能：
- 引入基于 Win32 的工具，用于查找和调整进程窗口大小，并确保游戏窗口的客户区匹配目标分辨率。
- 为 PinkPaw 抢劫方案 1、2、3 以及入口恢复流程添加自动 1280x720 分辨率调整，并在任务参数和流水线节点数据中提供可配置的自动调整开关。
- 添加一个可复用的 `resize_game_window` 自定义动作，可用于任意流水线，支持可配置分辨率以及基础调优选项（进程名、居中、容差、稳定等待时间）。

增强：
- 通过枚举候选窗口，并优先选择可见、已启用、具有有效客户区且面积最大的窗口来改进游戏窗口选择，支持可选的标题/类名过滤。
- 将 PinkPaw 通用参数和布尔值解析以及自动调整配置解析提取到共享的 `pinkpaw_common` 辅助模块中。

文档：
- 更新 README 致谢部分，增加对 OK-NTE 作为参考项目的致谢。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic Windows game window resolution management and shared configuration utilities for PinkPaw heist actions, and expose a generic resize-game-window custom action.

New Features:
- Introduce Win32-based utilities to find and resize process windows and ensure a game window client area matches a target resolution.
- Add automatic 1280x720 resolution adjustment for PinkPaw heist schemes 1, 2, 3 and the entrance recovery flow, with a configurable auto-resize switch in task parameters and pipeline node data.
- Add a reusable resize_game_window custom action for arbitrary pipelines, supporting configurable resolution and basic tuning options (process name, centering, tolerance, settle time).

Enhancements:
- Improve game window selection by enumerating candidate windows and preferring visible, enabled windows with valid client areas and the largest area, with optional title/class filters.
- Extract common PinkPaw parameter and boolean parsing plus auto-resize configuration resolution into a shared pinkpaw_common helper module.

Documentation:
- Update README acknowledgements to credit OK-NTE as a reference project.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

为 PinkPaw 抢劫（heist）动作添加自动 Windows 游戏窗口分辨率管理，并重构共享的 PinkPaw 配置解析逻辑。

新功能：
- 引入 Win32 工具，用于定位并将某个进程窗口的客户区调整到目标分辨率，并提供针对游戏窗口的专用辅助函数。
- 使 PinkPaw 抢劫方案 1、2、3 以及入口恢复流程在运行前可自动设置游戏窗口分辨率，默认使用 1280x720。
- 为 PinkPaw 任务新增可配置的 `auto_resize_game_window` 开关，默认值由流水线节点（pipeline node）驱动，并可在每次运行时进行覆盖。

增强内容：
- 通过枚举某个进程的候选窗口，并根据可见性、可用性、类名/标题过滤以及客户区大小来选择最合适的窗口，从而改进游戏窗口选择逻辑。
- 将通用的 PinkPaw 参数解析和布尔值处理提取到共享模块中，以减少重复代码。
- 在 README 的致谢部分中添加 OK-NTE。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 PinkPaw 抢劫动作添加自动 Windows 游戏窗口分辨率管理和共享配置工具，并公开一个通用的 resize-game-window 自定义动作。

新功能：
- 引入基于 Win32 的工具，用于查找和调整进程窗口大小，并确保游戏窗口的客户区匹配目标分辨率。
- 为 PinkPaw 抢劫方案 1、2、3 以及入口恢复流程添加自动 1280x720 分辨率调整，并在任务参数和流水线节点数据中提供可配置的自动调整开关。
- 添加一个可复用的 `resize_game_window` 自定义动作，可用于任意流水线，支持可配置分辨率以及基础调优选项（进程名、居中、容差、稳定等待时间）。

增强：
- 通过枚举候选窗口，并优先选择可见、已启用、具有有效客户区且面积最大的窗口来改进游戏窗口选择，支持可选的标题/类名过滤。
- 将 PinkPaw 通用参数和布尔值解析以及自动调整配置解析提取到共享的 `pinkpaw_common` 辅助模块中。

文档：
- 更新 README 致谢部分，增加对 OK-NTE 作为参考项目的致谢。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic Windows game window resolution management and shared configuration utilities for PinkPaw heist actions, and expose a generic resize-game-window custom action.

New Features:
- Introduce Win32-based utilities to find and resize process windows and ensure a game window client area matches a target resolution.
- Add automatic 1280x720 resolution adjustment for PinkPaw heist schemes 1, 2, 3 and the entrance recovery flow, with a configurable auto-resize switch in task parameters and pipeline node data.
- Add a reusable resize_game_window custom action for arbitrary pipelines, supporting configurable resolution and basic tuning options (process name, centering, tolerance, settle time).

Enhancements:
- Improve game window selection by enumerating candidate windows and preferring visible, enabled windows with valid client areas and the largest area, with optional title/class filters.
- Extract common PinkPaw parameter and boolean parsing plus auto-resize configuration resolution into a shared pinkpaw_common helper module.

Documentation:
- Update README acknowledgements to credit OK-NTE as a reference project.

</details>

</details>

</details>