### PR TITLE
fix: 修复做咖啡选择任务滚动过度

### DIFF
--- a/agent/custom/action/AutoCoffee/auto_make_coffee.py
+++ b/agent/custom/action/AutoCoffee/auto_make_coffee.py
@@ -51,7 +51,7 @@ class AutoMakeCoffee(CustomAction):
                         if context.tasker.stopping:
                             return CustomAction.RunResult(success=False)
                         context.run_action("MakeCoffeeScrollToTop")
-                        time.sleep(1)
+                        time.sleep(1.2)
                         img = get_image(controller)
                         target_result = context.run_recognition(
                             "MakeCoffeeTargetCoffeeMaster", img

--- a/agent/custom/action/AutoCoffee/auto_make_coffee_lite.py
+++ b/agent/custom/action/AutoCoffee/auto_make_coffee_lite.py
@@ -52,7 +52,7 @@ class AutoMakeCoffeeLite(CustomAction):
                         if context.tasker.stopping:
                             return CustomAction.RunResult(success=False)
                         context.run_action("MakeCoffeeScrollToTop")
-                        time.sleep(1)
+                        time.sleep(1.2)
                         img = get_image(controller)
                         target_result = context.run_recognition(
                             "MakeCoffeeTargetCoffeeMaster", img

--- a/assets/resource/base/pipeline/AutoCoffee/CoffeeAction.json
+++ b/assets/resource/base/pipeline/AutoCoffee/CoffeeAction.json
@@ -6,7 +6,7 @@
             120,
             400
         ],
-        "dy": 3600
+        "dy": 2800
     },
     "MakeCoffeeEnterShop": {
         "desc": "通过OCR识别店长特供并点击进入",


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue
#331
修复店长特供中,任务滚动过度选择到其他关卡
## 变更摘要

1. CoffeeAction.json滚动改为2800避免过度
2. auto_make_coffee.py和auto_make_coffee_lite.py滚动后等待时间改为1.2s更稳定

## 验证
win32-front
- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## Summary by Sourcery

调整自动咖啡滚动行为和时机，以在选择咖啡任务时防止滚动过头。

Bug Fixes:
- 增加自动咖啡脚本在滚动后的等待时间，以确保稳定识别目标咖啡任务，避免选择错误的关卡。

Enhancements:
- 调整咖啡操作的滚动参数，降低滚动越过目标任务的几率。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust auto coffee scrolling behavior and timing to prevent over-scrolling when selecting coffee tasks.

Bug Fixes:
- Increase post-scroll wait time in auto coffee scripts to ensure stable recognition of the target coffee task and avoid selecting the wrong level.

Enhancements:
- Tune coffee action scrolling parameters to reduce the chance of scrolling past the intended task.

</details>