### PR TITLE
fix(BagelSpam):修复因相册照片太少导致无法选中照片的bug

### DIFF
--- a/assets/resource/base/pipeline/BagelSpam.json
+++ b/assets/resource/base/pipeline/BagelSpam.json
@@ -391,6 +391,27 @@
             }
         },
         "next": [
+            "BagelSpamClickFirstRow1"
+        ]
+    },
+    "BagelSpamClickFirstRow1": {
+        "desc": "点击第一行第1张",
+        "recognition": {
+            "type": "DirectHit"
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    126,
+                    133,
+                    135,
+                    91
+                ]
+            }
+        },
+        "post_wait_freezes": 500,
+        "next": [
             "BagelSpamClickLastRow1"
         ]
     },


### PR DESCRIPTION
在点击最后一排照片前先点一下第一个照片，防止最后一排没照片导致点不到东西

## Summary by Sourcery

Bug Fixes:
- 解决当相册中照片过少时，最后一行的照片无法被选中的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where photos in the last row could not be selected when the album contained too few photos.

</details>