### PR TITLE
fix(RouteNavigation): 优化了资源加载，修复了多次调用寻路导致内存累积的严重问题

### DIFF
--- a/agent/custom/action/Navi/angle_predictor.py
+++ b/agent/custom/action/Navi/angle_predictor.py
@@ -1,5 +1,6 @@
 import math
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,6 +28,14 @@ class AnglePredictionResult:
 
 
 class AnglePredictor:
+    _session_cache = {}
+    _session_cache_lock = threading.Lock()
+    _provider_name_map = {
+        "cpu": "CPUExecutionProvider",
+        "directml": "DmlExecutionProvider",
+        "dml": "DmlExecutionProvider",
+    }
+
     def __init__(
         self,
         backend: str | None = None,
@@ -39,12 +48,6 @@ class AnglePredictor:
         self.pointer_roi = [73, 60, 64, 64]
         self.threshold = threshold
         self.debug = debug
-        self._session_cache = {}
-        self._provider_name_map = {
-            "cpu": "CPUExecutionProvider",
-            "directml": "DmlExecutionProvider",
-            "dml": "DmlExecutionProvider",
-        }
 
     def predict(self, frame: np.ndarray) -> AnglePredictionResult:
         session, _ = self.get_session()
@@ -151,7 +154,13 @@ class AnglePredictor:
 
     def close_debug(self) -> None:
         if self.debug:
-            cv2.destroyWindow("Angle Predictor")
+            try:
+                cv2.destroyWindow("Angle Predictor")
+            except cv2.error as exc:
+                logger.debug("Angle predictor debug window close failed: %s", exc)
+
+    def close(self) -> None:
+        self.close_debug()
 
     def provider_name(self) -> str:
         _, provider_name = self.get_session()
@@ -178,31 +187,34 @@ class AnglePredictor:
         return backend
 
     def get_session(self):
-        backend = self.backend
-        if backend in self._session_cache:
-            return self._session_cache[backend]
+        with self._session_cache_lock:
+            backend = self.backend
+            if backend in self._session_cache:
+                return self._session_cache[backend]
 
-        if not self.model_path.exists():
-            raise FileNotFoundError(f"Angle model not found: {self.model_path}")
+            if not self.model_path.exists():
+                raise FileNotFoundError(f"Angle model not found: {self.model_path}")
 
-        provider_name = self._provider_name_map[backend]
-        available = onnxruntime.get_available_providers()
-        if provider_name not in available:
-            logger.warning(
-                f"Requested provider {provider_name} is unavailable, available providers: {available}; fallback to CPU"
-            )
-            backend = "cpu"
-            self.backend = backend
             provider_name = self._provider_name_map[backend]
+            available = onnxruntime.get_available_providers()
+            if provider_name not in available:
+                logger.warning(
+                    f"Requested provider {provider_name} is unavailable, available providers: {available}; fallback to CPU"
+                )
+                backend = "cpu"
+                self.backend = backend
+                provider_name = self._provider_name_map[backend]
+                if backend in self._session_cache:
+                    return self._session_cache[backend]
 
-        provider_options = (
-            [{"device_id": 0}] if provider_name == "DmlExecutionProvider" else None
-        )
-        session = onnxruntime.InferenceSession(
-            str(self.model_path),
-            sess_options=onnxruntime.SessionOptions(),
-            providers=[provider_name],
-            provider_options=provider_options,
-        )
-        self._session_cache[backend] = (session, provider_name)
-        return self._session_cache[backend]
+            provider_options = (
+                [{"device_id": 0}] if provider_name == "DmlExecutionProvider" else None
+            )
+            session = onnxruntime.InferenceSession(
+                str(self.model_path),
+                sess_options=onnxruntime.SessionOptions(),
+                providers=[provider_name],
+                provider_options=provider_options,
+            )
+            self._session_cache[backend] = (session, provider_name)
+            return self._session_cache[backend]

--- a/agent/custom/action/Navi/map_locator.py
+++ b/agent/custom/action/Navi/map_locator.py
@@ -1,5 +1,7 @@
 import math
+import threading
 from dataclasses import dataclass
+from typing import Any
 
 import cv2
 import numpy as np
@@ -56,46 +58,31 @@ class MapLocator:
     DEBUG_ZOOM_RADIUS_DEFAULT = 400
     DEBUG_ZOOM_RADIUS_MAX = 2000
     DEBUG_WIN = "Map Locator"
+    _shared_assets: dict[str, Any] | None = None
+    _shared_assets_lock = threading.Lock()
 
     def __init__(self, debug: bool = False):
-        self.big_map_path = resource_base_path() / "image/map/bigworldmapSecond.png"
-        self.chat_button_path = (
-            resource_base_path() / "image/Common/Button/InWorld/Chat.png"
-        )
-
-        self.chat_template = cv2.imread(str(self.chat_button_path), cv2.IMREAD_COLOR)
+        self._closed = False
+        assets = self.shared_assets()
+        self.big_map_path = assets["big_map_path"]
+        self.chat_button_path = assets["chat_button_path"]
+        self.chat_template = assets["chat_template"]
         self.debug = debug
         self.last_center: tuple[int, int] | None = None
         self.smoothed_center: tuple[float, float] | None = None
         self._active_map_crop_index = 0
-
-        big_gray = cv2.imread(str(self.big_map_path), cv2.IMREAD_GRAYSCALE)
-        if big_gray is None:
-            raise ValueError(f"Failed to read big map: {self.big_map_path}")
-
-        self.origin_h, self.origin_w = big_gray.shape
-        if (self.origin_w, self.origin_h) != self.MAP_SIZE:
-            logger.warning(
-                f"Unexpected big map size: {self.origin_w}x{self.origin_h}, "
-                f"expected {self.MAP_SIZE[0]}x{self.MAP_SIZE[1]}"
-            )
+        self.origin_h = assets["origin_h"]
+        self.origin_w = assets["origin_w"]
 
         # 由于模板匹配对缩放敏感，需要预生成多尺度匹配模板，适配不同速度下的小地图尺寸
         # Fucking Neverness to Everness
-        self._match_maps: list[tuple[float, np.ndarray]] = []
-        for map_crop_size in self.MAP_CROP_SIZES:
-            scale = self.MINI_MAP_ROI[2] / map_crop_size
-            match_size = (
-                int(round(self.origin_w * scale)),
-                int(round(self.origin_h * scale)),
-            )
-            resized_gray = cv2.resize(
-                big_gray, match_size, interpolation=cv2.INTER_AREA
-            )
-            self._match_maps.append((scale, resized_gray))
+        self._match_maps = assets["match_maps"]
         self.activate_map_crop_size(0)
 
         if self.debug:
+            big_gray = cv2.imread(str(self.big_map_path), cv2.IMREAD_GRAYSCALE)
+            if big_gray is None:
+                raise ValueError(f"Failed to read big map: {self.big_map_path}")
             self.debug_scale = min(1.0, self.DEBUG_MAP_WIDTH / self.origin_w)
             debug_size = (
                 int(round(self.origin_w * self.debug_scale)),
@@ -129,6 +116,78 @@ class MapLocator:
             f"crop_sizes={self.MAP_CROP_SIZES}"
         )
 
+    @classmethod
+    def shared_assets(cls) -> dict[str, Any]:
+        with cls._shared_assets_lock:
+            if cls._shared_assets is None:
+                cls._shared_assets = cls.load_shared_assets()
+            return cls._shared_assets
+
+    @classmethod
+    def load_shared_assets(cls) -> dict[str, Any]:
+        big_map_path = resource_base_path() / "image/map/bigworldmapSecond.png"
+        chat_button_path = resource_base_path() / "image/Common/Button/InWorld/Chat.png"
+        chat_template = cv2.imread(str(chat_button_path), cv2.IMREAD_COLOR)
+        big_gray = cv2.imread(str(big_map_path), cv2.IMREAD_GRAYSCALE)
+        if big_gray is None:
+            raise ValueError(f"Failed to read big map: {big_map_path}")
+
+        origin_h, origin_w = big_gray.shape
+        if (origin_w, origin_h) != cls.MAP_SIZE:
+            logger.warning(
+                f"Unexpected big map size: {origin_w}x{origin_h}, "
+                f"expected {cls.MAP_SIZE[0]}x{cls.MAP_SIZE[1]}"
+            )
+
+        match_maps: list[tuple[float, np.ndarray]] = []
+        for map_crop_size in cls.MAP_CROP_SIZES:
+            scale = cls.MINI_MAP_ROI[2] / map_crop_size
+            match_size = (
+                int(round(origin_w * scale)),
+                int(round(origin_h * scale)),
+            )
+            resized_gray = cv2.resize(
+                big_gray,
+                match_size,
+                interpolation=cv2.INTER_AREA,
+            )
+            match_maps.append((scale, resized_gray))
+
+        logger.info(
+            f"NCC shared map assets loaded: origin={origin_w}x{origin_h}, "
+            f"crop_sizes={cls.MAP_CROP_SIZES}"
+        )
+        return {
+            "big_map_path": big_map_path,
+            "chat_button_path": chat_button_path,
+            "chat_template": chat_template,
+            "origin_h": origin_h,
+            "origin_w": origin_w,
+            "match_maps": match_maps,
+        }
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        if self.debug and getattr(self, "_debug_win_ready", False):
+            try:
+                cv2.destroyWindow(self.DEBUG_WIN)
+            except cv2.error as exc:
+                logger.debug("Map locator debug window close failed: %s", exc)
+            self._debug_win_ready = False
+
+        self.chat_template = None
+        self.last_center = None
+        self.smoothed_center = None
+        self._match_maps = []
+        self.big_match = None
+
+        if self.debug:
+            self.debug_map = None
+            self.zoom_map = None
+
     def activate_map_crop_size(self, index: int) -> None:
         previous_size = getattr(self, "map_crop_size", None)
         self._active_map_crop_index = index
@@ -160,6 +219,9 @@ class MapLocator:
         )
 
     def locate(self, frame: np.ndarray) -> MapLocationResult:
+        if self._closed:
+            raise RuntimeError("map locator is closed")
+
         x, y, w, h = self.MINI_MAP_ROI
         if frame is None or y + h > frame.shape[0] or x + w > frame.shape[1]:
             raise ValueError(

--- a/agent/custom/action/Navi/waypoint_navigator.py
+++ b/agent/custom/action/Navi/waypoint_navigator.py
@@ -211,8 +211,14 @@ class WaypointNavigator:
         try:
             self.release()
         finally:
-            if self.debug:
-                close_debug_windows()
+            try:
+                self.locator.close()
+            finally:
+                try:
+                    self.predictor.close()
+                finally:
+                    if self.debug:
+                        close_debug_windows()
 
     def sleep_remaining(self, started: float) -> None:
         sleep_time = self.frame_interval - (time.perf_counter() - started)

--- a/assets/resource/base/pipeline/LocalRouteNavigationMemoryTest.json
+++ b/assets/resource/base/pipeline/LocalRouteNavigationMemoryTest.json
@@ -1,0 +1,347 @@
+{
+    "LocalRouteNavigationMemoryTest": {
+        "desc": "Memory test entry for repeated local_route_navigation custom actions.",
+        "action": "DoNothing",
+        "next": [
+            "LocalRouteNavigationMemoryTest01Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest01Segment1": {
+        "desc": "Memory test round 01, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest01Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest01Segment2": {
+        "desc": "Memory test round 01, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest02Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest02Segment1": {
+        "desc": "Memory test round 02, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest02Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest02Segment2": {
+        "desc": "Memory test round 02, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest03Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest03Segment1": {
+        "desc": "Memory test round 03, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest03Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest03Segment2": {
+        "desc": "Memory test round 03, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest04Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest04Segment1": {
+        "desc": "Memory test round 04, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest04Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest04Segment2": {
+        "desc": "Memory test round 04, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest05Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest05Segment1": {
+        "desc": "Memory test round 05, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest05Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest05Segment2": {
+        "desc": "Memory test round 05, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest06Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest06Segment1": {
+        "desc": "Memory test round 06, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest06Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest06Segment2": {
+        "desc": "Memory test round 06, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest07Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest07Segment1": {
+        "desc": "Memory test round 07, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest07Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest07Segment2": {
+        "desc": "Memory test round 07, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest08Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest08Segment1": {
+        "desc": "Memory test round 08, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest08Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest08Segment2": {
+        "desc": "Memory test round 08, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest09Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest09Segment1": {
+        "desc": "Memory test round 09, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest09Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest09Segment2": {
+        "desc": "Memory test round 09, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest10Segment1"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest10Segment1": {
+        "desc": "Memory test round 10, unittest segment 1.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 1,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": [
+            "LocalRouteNavigationMemoryTest10Segment2"
+        ]
+    },
+    "LocalRouteNavigationMemoryTest10Segment2": {
+        "desc": "Memory test round 10, unittest segment 2.",
+        "action": "Custom",
+        "custom_action": "local_route_navigation",
+        "custom_action_param": {
+            "json_path": "unittest",
+            "route_name": "unittest",
+            "segment_index": 2,
+            "frame_interval": 0.1,
+            "tolerance": 5,
+            "angle_backend": "auto",
+            "debug": false
+        },
+        "next": []
+    }
+}

--- a/assets/resource/routes/unittest.json
+++ b/assets/resource/routes/unittest.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "routes": [
+    {
+      "id": "route-1781405382525",
+      "name": "unittest",
+      "isHidden": false,
+      "segments": [
+        {
+          "id": "segment-1781405397659",
+          "name": "1",
+          "isHidden": false,
+          "points": [
+            {
+              "lat": 17.954545,
+              "lng": -96.681818
+            },
+            {
+              "lat": 18.772727,
+              "lng": -94.920455
+            }
+          ]
+        },
+        {
+          "id": "segment-1781405412378",
+          "name": "2",
+          "isHidden": false,
+          "points": [
+            {
+              "lat": 18.875,
+              "lng": -95.034091
+            },
+            {
+              "lat": 17.965909,
+              "lng": -96.795455
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/assets/resource/tasks/LocalRouteNavigationMemoryTest.json
+++ b/assets/resource/tasks/LocalRouteNavigationMemoryTest.json
@@ -1,0 +1,14 @@
+{
+    "task": [
+        {
+            "name": "LocalRouteNavigationMemoryTest",
+            "label": "[测试] 本地路线内存测试",
+            "description": "连续调用 local_route_navigation，使用 unittest 路线在 segment 1 和 segment 2 之间交替执行 10 轮。",
+            "entry": "LocalRouteNavigationMemoryTest",
+            "group": [
+                "RealTimeAssist"
+            ]
+        }
+    ],
+    "option": {}
+}


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

需求来源：本地路线寻路内存占用排查。反复在 Pipeline 中调用 `local_route_navigation` 时，Python 进程内存会随 segment 调用次数持续累计，最高可涨到 1200M 以上。

## 变更摘要

- 为 `MapLocator` 增加进程级共享资源缓存，复用大地图、多尺度匹配图和聊天按钮模板，避免每次 CustomAction 重新加载和 resize 大图。
- 为 `AnglePredictor` 增加按 backend 共享的 ONNXRuntime session cache，避免反复创建 DirectML/CPU 推理 session 导致 native 内存累计。
- 保留 `WaypointNavigator.close()` 的实例级清理，释放按键状态、调试窗口和本次导航状态，但不再销毁可复用的重资源。
- 新增 `LocalRouteNavigationMemoryTest` 测试 Pipeline，使用 `unittest` 路线交替执行 segment 1/2 共 10 轮，便于观察内存是否继续阶梯式上涨。

## 验证

- 测试入口：`[测试] 本地路线内存测试` / `LocalRouteNavigationMemoryTest`
- 路线：`assets/resource/routes/unittest.json`
- 调用方式：连续调用 `local_route_navigation` 20 次，segment 顺序为 `1, 2` 交替，共 10 轮。
- 验证结果：修复前反复调用寻路时 Python 进程内存持续累计，可涨到 1200M 以上；修复后首次加载导航资源后内存上升，后续 segment 交替执行不再持续累计。
- 静态验证：已执行 `python -m py_compile` 检查 Navi 相关 Python 文件；新增测试 Pipeline JSON 已通过解析检查，并确认节点链为 `[1, 2] * 10`。

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

本次为内存生命周期修复，无识别模板、点击 ROI 或界面跳转变更。

说明：本修复不会让导航结束后 Python 进程内存回到启动时的 50M。大地图匹配缓存和 ONNXRuntime session 会作为进程级共享资源常驻一份，预期行为是首次导航后内存上升，之后反复调用 Pipeline 不再继续阶梯式累加。

## Summary by Sourcery

为高开销的导航资源和 ONNX 运行时会话引入进程级共享缓存，以防止在多次本地路径导航运行中内存不断增长，并新增专门的流水线用于验证内存行为。

New Features:
- 在 MapLocator 中添加进程级共享资源缓存，用于大型地图数据、多尺度匹配模板以及聊天按钮模板。
- 在 AnglePredictor 中添加按后端键控的共享 ONNXRuntime 会话缓存。
- 引入 LocalRouteNavigationMemoryTest 流水线和路由，用于交替运行不同路段并观察内存使用情况。

Bug Fixes:
- 通过重用高开销的地图资源和 ONNX 会话，而不是在每次导航时重新创建，防止在重复调用 `local_route_navigation` 时原生和 Python 内存无限增长。

Enhancements:
- 为 MapLocator 和 AnglePredictor 添加显式的关闭方法，并从 `WaypointNavigator.close` 中调用它们，以在不销毁共享资源的情况下清理每次运行的状态和调试窗口。
- 使 AnglePredictor 会话初始化在提供者不可用时更加健壮：在回退到 CPU 的同时，仍然利用共享会话缓存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce shared, process-level caching for heavy navigation resources and ONNX runtime sessions to prevent memory growth across repeated local route navigation runs, and add a dedicated pipeline to validate memory behavior.

New Features:
- Add process-level shared asset cache in MapLocator for big map data, multi-scale match templates, and chat button template.
- Add a shared ONNXRuntime session cache in AnglePredictor keyed by backend.
- Introduce LocalRouteNavigationMemoryTest pipeline and routes to exercise alternating segments and observe memory usage.

Bug Fixes:
- Prevent unbounded native and Python memory growth when repeatedly invoking local_route_navigation by reusing heavy map assets and ONNX sessions instead of recreating them per navigation.

Enhancements:
- Add explicit close methods to MapLocator and AnglePredictor and invoke them from WaypointNavigator.close to clean up per-run state and debug windows without destroying shared resources.
- Make AnglePredictor session initialization robust to unavailable providers by falling back to CPU while still leveraging the shared session cache.

</details>