### PR TITLE
fix(Fishnew) : 修复了两处钓鱼脚本bug

### DIFF
--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -422,7 +422,8 @@
         },
         "action": "Click",
         "next": [
-            "[Anchor]FishNewRestart"
+            "[Anchor]FishNewRestart",
+            "[Anchor]FishNewErrorRestart"
         ]
     },
     "FishNewStoreChooseGeneralBait": {
@@ -760,6 +761,7 @@
             "빠른 제출"
         ],
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "[JumpBack]SceneClickBlankToExit",
             "FishNewFishingMasterPage1Sell2"
@@ -806,6 +808,7 @@
             "빠른 제출"
         ],
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "[JumpBack]SceneClickBlankToExit",
             "FishNewFishingMasterPage1Sell3"
@@ -852,6 +855,7 @@
             "빠른 제출"
         ],
         "action": "Click",
+        "post_wait_freezes": 500,
         "next": [
             "[JumpBack]SceneClickBlankToExit",
             "FishNewFishingMasterSwitchToPage2"


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

发现的两处bug
1：钓鱼准备界面未装备鱼饵会走到fishnewusebait,fishnewusebait的next节点fishnewcast会因为识别不到抛竿界面任务失败（此时还在钓鱼准备界面）
<img width="1921" height="1047" alt="image" src="https://github.com/user-attachments/assets/aa1026d2-1e7c-4439-8486-d7d8600a1800" />

2.FishNewFishingMasterPage1Submit三个节点点击后没有设置延迟导致“点击空白处关闭界面”界面跳出来之前就进行到下一个节点，sceneclickblanktoexit节点没有识别触发导致状态错误
[2026.06.16-13.58.42.908_FishNewOpenFishMaster_wait_freezes.zip](https://github.com/user-attachments/files/28987040/2026.06.16-13.58.42.908_FishNewOpenFishMaster_wait_freezes.zip)

## 变更摘要

针对1：fishnewusebait的next列表多一个指向fishnewentrance的去向
针对2：三个相关节点增加post_wait_freeze500ms

## 验证

fishnewusebait执行完后成功回到了fishnewentrance
<img width="2031" height="870" alt="image" src="https://github.com/user-attachments/assets/6bb0c131-b902-4bce-be20-b4cec46527db" />

fishnewfishingmasterpage1submit可以成功触发sceneclickblanktoexit
<img width="1278" height="655" alt="image" src="https://github.com/user-attachments/assets/091e87ca-dfd6-403b-8d96-66cc90de7f80" />

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## Summary by Sourcery

修复 FishNew 自动化流水线中的钓鱼工作流漏洞。

错误修复：
- 修正 FishNew 流程：当在钓鱼准备界面未装备鱼饵时，流程会返回到 FishNew 入口，而不是在抛竿步骤失败。
- 为 FishNew 主页面的提交步骤增加适当的后置延迟，以便能够可靠地触发“点击空白区域退出”场景，避免状态不同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix fishing workflow bugs in the FishNew automation pipeline.

Bug Fixes:
- Correct the FishNew flow so that when no bait is equipped from the fishing preparation screen, the sequence returns to the FishNew entrance instead of failing at the casting step.
- Add appropriate post-action delays to FishNew master page submit steps so that the blank-area-to-exit scene can be triggered reliably without state desynchronization.

</details>