### PR TITLE
fix(controller): Win32-Front 键盘改用 Seize（SendInput），修复 UE 客户端按键无效

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 env:
-  MAA_FRAMEWORK_VERSION: "v5.10.4"
+  MAA_FRAMEWORK_VERSION: "v5.10.5"
   MXU_VERSION: "v2.1.3"
 
 permissions:

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -40,7 +40,7 @@
                 "window_regex": "^\\s*(异环|NTE)\\s*$",
                 "screencap": "PrintWindow",
                 "mouse": "Seize",
-                "keyboard": "PostMessage"
+                "keyboard": "Seize"
             }
         },
         {

--- a/build.py
+++ b/build.py
@@ -31,7 +31,7 @@ from pathlib import Path
 # 可配置常量
 # ---------------------------------------------------------------------------
 
-MAA_FRAMEWORK_VERSION = "v5.10.4"
+MAA_FRAMEWORK_VERSION = "v5.10.5"
 MFAA_VERSION = "v2.12.1"
 MXU_VERSION = "v2.1.3"
 PYTHON_VERSION_TARGET = "3.12.10"


### PR DESCRIPTION
## 关联

Closes #349

## 摘要

把 `assets/interface.json` 中 `Win32-Front` 控制器的 `win32.keyboard` 从 `"PostMessage"` 改为 `"Seize"`。

**注意**：仅改 `interface.json` 不够，还需要升级 MaaFramework 到 v5.10.5+（详见 #349 评论更新）。当前打包的 v5.10.4 的 `SeizeInput::key_down/key_up` 缺少 `wScan`（硬件扫描码），UE 的 Raw Input 不识别 wScan=0 的按键事件。MaaFramework PR [#1307](https://github.com/MaaXYZ/MaaFramework/pull/1307) 已修但未进入 v5.10.4。v5.10.5+ 包含此修复。

## 背景

详见 #349。简述两层根因：

1. **第一层**：`keyboard: "PostMessage"` → WM_KEYDOWN → UE 不响应（已修：改 Seize）
2. **第二层**：MaaFramework v5.10.4 的 SeizeInput::key_down 缺 wScan → SendInput 的 KEYBDINPUT.wScan=0 → UE Raw Input 仍不识别（需要升级 MaaFramework 到 v5.10.5+）

## 改动

- `assets/interface.json`：`Win32-Front.win32.keyboard`: `"PostMessage"` → `"Seize"`
- `Win32`（默认/后台）与 `Win32-Background` 保持 `PostMessage` 不变 —— Seize 是前台抢占式输入，不能用于后台

## 验证

- [ ] 升级 MaaFramework 到 v5.10.5+ 后，用 `Win32-Front` 跑一遍 SoundDodge，确认游戏内角色对按键有响应
- [ ] 顺带回归一遍其他前台任务：RealTime、PinkPawHeist、MakeCoffee、FountainCheckin、Furniture、WitchDivination 至少冒烟一次

## 风险

低：仅 1 行配置，作用域为 Win32-Front 控制器。MaaFramework 升级是独立步骤，不影响其他控制器或 Pipeline。
