### PR TITLE
fix(领取奖励):修复领取每日奖励时动画未放完导致领取失败

### DIFF
--- a/assets/resource/base/pipeline/ClaimRewards.json
+++ b/assets/resource/base/pipeline/ClaimRewards.json
@@ -63,7 +63,7 @@
             }
         },
         "action": "Click",
-        "post_delay": 500
+        "post_wait_freezes": 500
     },
     "ClaimRewardsActivityRewards": {
         "desc": "领取活跃度奖励（活跃度奖励部分结束）",


### PR DESCRIPTION
点击领取按钮后改用wait_freeze来等待动画结束，避免点太快动画还没结束，导致没有领到奖励

## Summary by Sourcery

错误修复：
- 防止在动画尚未完成时再次点击领取按钮，导致每日奖励领取失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent daily reward claims from failing when the claim button is clicked again before the animation finishes.

</details>