### PR TITLE
fix(sound-dodge): 修复模式配置并提升闪避响应稳定性

### DIFF
--- a/agent/custom/action/SoundTrigger/DodgeCounterTrigger.py
+++ b/agent/custom/action/SoundTrigger/DodgeCounterTrigger.py
@@ -46,10 +46,10 @@ class Dodger:
             if self._busy:
                 return
             self._busy = True
+            self._last_dodge = time.time()
 
         try:
             self.dodge_fn()
-            self._last_dodge = time.time()
         except Exception as e:
             _log().error(f"Dodge failed: {e}")
         finally:
@@ -66,10 +66,10 @@ class Dodger:
             if self._busy:
                 return
             self._busy = True
+            self._last_counter = time.time()
 
         try:
             self.counter_fn()
-            self._last_counter = time.time()
         except Exception as e:
             _log().error(f"Counter failed: {e}")
         finally:
@@ -83,7 +83,7 @@ class Dodger:
     def _default_dodge(self):
         _log().info("执行按键: 左Shift按下 -> 左Shift释放")
         self._click_key(VK_SHIFT)
-        time.sleep(0.1 + random.random() * 0.2)
+        time.sleep(0.1 + random.random() * 0.1)
         self._click_key(VK_SHIFT)
 
     def _default_counter(self):

--- a/agent/custom/action/SoundTrigger/SoundDodgeAction.py
+++ b/agent/custom/action/SoundTrigger/SoundDodgeAction.py
@@ -1,6 +1,6 @@
 import json
+import queue
 import threading
-import time
 from pathlib import Path
 
 from maa.agent.agent_server import AgentServer
@@ -15,9 +15,52 @@ from utils.maafocus import PrintT
 logger = get_logger(__name__)
 
 
+def _parse_bool(value, default=False):
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+            "enable",
+            "enabled",
+        }
+    return bool(default)
+
+
+def _parse_params(value):
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return value
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise TypeError("custom_action_param must be a JSON object")
+    return parsed
+
+
+def _get_config_value(context, node_name, key, default):
+    try:
+        node_data = context.get_node_data(node_name) or {}
+    except Exception as exc:
+        logger.warning("Failed to read %s: %s", node_name, exc)
+        return default
+    attach = node_data.get("attach") if isinstance(node_data, dict) else None
+    if not isinstance(attach, dict):
+        return default
+    return attach.get(key, default)
+
+
 class Ctx:
     def __init__(self):
         self._stop_event = threading.Event()
+        self._action_queue = queue.Queue(maxsize=1)
         self.ear = None
         self.dodger = None
         self.active = False
@@ -25,7 +68,13 @@ class Ctx:
     def _stopped(self):
         return self._stop_event.is_set()
 
-    def setup(self, controller, threshold=0.13, counter_threshold=0.12):
+    def setup(
+        self,
+        controller,
+        threshold=0.13,
+        counter_threshold=0.12,
+        dodge_all_attacks=True,
+    ):
         if self.active:
             return
 
@@ -45,9 +94,13 @@ class Ctx:
         )
         self.dodger = Dodger(controller=controller, stop_check=self._stopped)
         self.ear.on_dodge = self._on_dodge
-        self.ear.on_counter = self._on_counter
+        self.ear.on_counter = (
+            self._on_dodge if dodge_all_attacks else self._on_counter
+        )
         self.active = True
-        logger.debug("Ctx initialized")
+        logger.debug(
+            "Ctx initialized, dodge_all_attacks=%s", dodge_all_attacks
+        )
 
     def enter(self):
         self._stop_event.clear()
@@ -66,17 +119,32 @@ class Ctx:
         self.active = False
         logger.debug("Ctx exited")
 
-    def _on_dodge(self):
+    def _enqueue_action(self, action):
         if self._stopped():
             return
-        if self.dodger:
-            threading.Thread(target=self.dodger.dodge, daemon=True).start()
+        try:
+            self._action_queue.put_nowait(action)
+        except queue.Full:
+            logger.debug("Dropping stale sound action: %s", action)
+
+    def _on_dodge(self):
+        self._enqueue_action("dodge")
 
     def _on_counter(self):
-        if self._stopped():
-            return
-        if self.dodger:
-            threading.Thread(target=self.dodger.counter, daemon=True).start()
+        self._enqueue_action("counter")
+
+    def process_next(self, timeout=0.05):
+        if self._stopped() or not self.dodger:
+            return False
+        try:
+            action = self._action_queue.get(timeout=timeout)
+        except queue.Empty:
+            return False
+        if action == "dodge":
+            self.dodger.dodge()
+        else:
+            self.dodger.counter()
+        return True
 
 
 @AgentServer.custom_action("SoundDodgeAction")
@@ -84,19 +152,76 @@ class SoundDodgeAction(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
-        PrintT(context, "sound_dodge.started")
-
+        enable_sound_trigger = True
+        dodge_all_attacks = True
         threshold = 0.13
         counter_threshold = 0.12
         if argv.custom_action_param:
             try:
-                p = json.loads(argv.custom_action_param)
-                threshold = float(p.get("threshold", 0.13))
-                counter_threshold = float(p.get("counter_attack_threshold", 0.12))
+                p = _parse_params(argv.custom_action_param)
+                parsed_enable = _parse_bool(p.get("enable_sound_trigger"), True)
+                parsed_dodge_all = _parse_bool(p.get("dodge_all_attacks"), True)
+                parsed_threshold = float(p.get("threshold", 0.13))
+                parsed_counter_threshold = float(
+                    p.get("counter_attack_threshold", 0.12)
+                )
             except (json.JSONDecodeError, ValueError, TypeError) as e:
                 logger.warning(
                     f"Invalid custom_action_param: {argv.custom_action_param!r}, error: {e}. Using defaults."
                 )
+            else:
+                enable_sound_trigger = parsed_enable
+                dodge_all_attacks = parsed_dodge_all
+                threshold = parsed_threshold
+                counter_threshold = parsed_counter_threshold
+
+        enable_sound_trigger = _parse_bool(
+            _get_config_value(
+                context,
+                "SoundDodgeEnableConfig",
+                "enable_sound_trigger",
+                enable_sound_trigger,
+            ),
+            enable_sound_trigger,
+        )
+        dodge_all_attacks = _parse_bool(
+            _get_config_value(
+                context,
+                "SoundDodgeModeConfig",
+                "dodge_all_attacks",
+                dodge_all_attacks,
+            ),
+            dodge_all_attacks,
+        )
+        try:
+            threshold = float(
+                _get_config_value(
+                    context,
+                    "SoundDodgeThresholdConfig",
+                    "threshold",
+                    threshold,
+                )
+            )
+            counter_threshold = float(
+                _get_config_value(
+                    context,
+                    "SoundCounterThresholdConfig",
+                    "counter_attack_threshold",
+                    counter_threshold,
+                )
+            )
+        except (TypeError, ValueError) as exc:
+            logger.warning("Invalid sound dodge config: %s", exc)
+
+        if not enable_sound_trigger:
+            logger.info("Sound dodge is disabled")
+            return CustomAction.RunResult(success=True)
+
+        PrintT(context, "sound_dodge.started")
+        logger.info(
+            "Sound dodge mode: %s",
+            "dodge-only" if dodge_all_attacks else "dodge+counter",
+        )
 
         ctx = Ctx()
         try:
@@ -104,13 +229,14 @@ class SoundDodgeAction(CustomAction):
                 context.tasker.controller,
                 threshold=threshold,
                 counter_threshold=counter_threshold,
+                dodge_all_attacks=dodge_all_attacks,
             )
             if not ctx.enter():
                 return CustomAction.RunResult(success=False)
 
             PrintT(context, "sound_dodge.monitoring")
             while not context.tasker.stopping:
-                time.sleep(0.1)
+                ctx.process_next(timeout=0.05)
 
             PrintT(context, "sound_dodge.interrupted")
             return CustomAction.RunResult(success=True)

--- a/agent/custom/action/SoundTrigger/SoundDodgeAction.py
+++ b/agent/custom/action/SoundTrigger/SoundDodgeAction.py
@@ -40,6 +40,8 @@ def _parse_params(value):
     if isinstance(value, dict):
         return value
     parsed = json.loads(value)
+    if parsed is None:
+        return {}
     if not isinstance(parsed, dict):
         raise TypeError("custom_action_param must be a JSON object")
     return parsed

--- a/agent/custom/action/SoundTrigger/SoundListener.py
+++ b/agent/custom/action/SoundTrigger/SoundListener.py
@@ -27,8 +27,8 @@ class Ear:
     ch = 2
     chunk = 1600
     sample_len = 0.2
-    interval = 0.1
-    log_every = 20
+    interval = 0.05
+    log_every = 40
     degree = 4
     cut_off = 1000
 
@@ -196,14 +196,19 @@ class Ear:
         if now - self._last_trigger < self._trigger_cd:
             return
 
-        if d_score >= self.threshold:
+        dodge_hit = d_score >= self.threshold
+        counter_hit = c_score >= self.counter_threshold
+        dodge_confidence = d_score / max(self.threshold, 1e-6)
+        counter_confidence = c_score / max(self.counter_threshold, 1e-6)
+
+        if dodge_hit and (not counter_hit or dodge_confidence >= counter_confidence):
             self._last_trigger = now
             _log().info(f"闪避触发分数: {d_score:.5f}")
             if self.on_dodge:
                 self.on_dodge()
             return
 
-        if c_score >= self.counter_threshold:
+        if counter_hit:
             self._last_trigger = now
             _log().info(f"反击触发分数: {c_score:.5f}")
             if self.on_counter:

--- a/assets/resource/base/pipeline/SoundDodge/SoundDodge.json
+++ b/assets/resource/base/pipeline/SoundDodge/SoundDodge.json
@@ -2,11 +2,29 @@
     "SoundDodgeMain": {
         "desc": "音频闪避主入口",
         "action": "Custom",
-        "custom_action": "SoundDodgeAction",
-        "custom_action_param": {
-            "enable_sound_trigger": true,
-            "dodge_all_attacks": true,
-            "threshold": 0.13,
+        "custom_action": "SoundDodgeAction"
+    },
+    "SoundDodgeEnableConfig": {
+        "enabled": false,
+        "attach": {
+            "enable_sound_trigger": true
+        }
+    },
+    "SoundDodgeModeConfig": {
+        "enabled": false,
+        "attach": {
+            "dodge_all_attacks": true
+        }
+    },
+    "SoundDodgeThresholdConfig": {
+        "enabled": false,
+        "attach": {
+            "threshold": 0.13
+        }
+    },
+    "SoundCounterThresholdConfig": {
+        "enabled": false,
+        "attach": {
             "counter_attack_threshold": 0.12
         }
     }

--- a/assets/resource/tasks/SoundDodge.json
+++ b/assets/resource/tasks/SoundDodge.json
@@ -34,8 +34,8 @@
                     "name": "No",
                     "label": "$option_switch_case_no",
                     "pipeline_override": {
-                        "SoundDodgeMain": {
-                            "custom_action_param": {
+                        "SoundDodgeEnableConfig": {
+                            "attach": {
                                 "enable_sound_trigger": false
                             }
                         }
@@ -53,8 +53,8 @@
                     "name": "Yes",
                     "label": "$task_sound_dodge_option_dodge_only_case_yes",
                     "pipeline_override": {
-                        "SoundDodgeMain": {
-                            "custom_action_param": {
+                        "SoundDodgeModeConfig": {
+                            "attach": {
                                 "dodge_all_attacks": true
                             }
                         }
@@ -64,8 +64,8 @@
                     "name": "No",
                     "label": "$task_sound_dodge_option_dodge_only_case_no",
                     "pipeline_override": {
-                        "SoundDodgeMain": {
-                            "custom_action_param": {
+                        "SoundDodgeModeConfig": {
+                            "attach": {
                                 "dodge_all_attacks": false
                             }
                         }
@@ -87,8 +87,8 @@
                 }
             ],
             "pipeline_override": {
-                "SoundDodgeMain": {
-                    "custom_action_param": {
+                "SoundDodgeThresholdConfig": {
+                    "attach": {
                         "threshold": "{threshold}"
                     }
                 }
@@ -107,8 +107,8 @@
                 }
             ],
             "pipeline_override": {
-                "SoundDodgeMain": {
-                    "custom_action_param": {
+                "SoundCounterThresholdConfig": {
+                    "attach": {
                         "counter_attack_threshold": "{counter_threshold}"
                     }
                 }

--- a/docs/zh_cn/introduction/SoundDodge.md
+++ b/docs/zh_cn/introduction/SoundDodge.md
@@ -22,22 +22,22 @@
 
 "音频闪避"功能的总开关。关闭时会同时关闭闪避和反击。
 
-**具体实现**：开关 `SoundDodgeEnable`，默认开启。关闭时将 `SoundDodgeMain` 的 `enable_sound_trigger` 覆写为 `false`。
+**具体实现**：开关 `SoundDodgeEnable`，默认开启。关闭时将 `SoundDodgeEnableConfig.attach.enable_sound_trigger` 覆写为 `false`。
 
 ### 仅闪避模式
 
 开启后只执行闪避，不执行反击。
 
-**具体实现**：开关 `SoundDodgeAllAttacks`，默认仅闪避。开启时设置 `dodge_all_attacks` 为 `true`（仅闪避）；关闭时设置为 `false`（闪避+反击）。
+**具体实现**：开关 `SoundDodgeAllAttacks`，默认仅闪避。开启时将 `SoundDodgeModeConfig.attach.dodge_all_attacks` 设置为 `true`，两种音效都触发闪避；关闭时设置为 `false`，反击音效触发反击。
 
 ### 闪避阈值
 
 闪避音效识别阈值，范围 0.0~1.0，**越低越敏感**。如果漏闪避，请调低数值；如果误闪避，请调高数值。
 
-**具体实现**：`string` 类型输入框 `SoundDodgeThreshold`，默认 `0.13`。通过 `^0\.\d+$|^1\.0*$` 校验。覆写 `SoundDodgeMain` 的 `custom_action_param.threshold` 参数。
+**具体实现**：`string` 类型输入框 `SoundDodgeThreshold`，默认 `0.13`。通过 `^0\.\d+$|^1\.0*$` 校验。覆写 `SoundDodgeThresholdConfig.attach.threshold`。
 
 ### 反击阈值
 
 反击音效识别阈值，范围 0.0~1.0，**越低越敏感**。如果漏反击，请调低数值；如果误反击，请调高数值。
 
-**具体实现**：`string` 类型输入框 `SoundCounterThreshold`，默认 `0.12`。通过 `^0\.\d+$|^1\.0*$` 校验。覆写 `SoundDodgeMain` 的 `custom_action_param.counter_attack_threshold` 参数。
+**具体实现**：`string` 类型输入框 `SoundCounterThreshold`，默认 `0.12`。通过 `^0\.\d+$|^1\.0*$` 校验。覆写 `SoundCounterThresholdConfig.attach.counter_attack_threshold`；仅闪避模式下命中该音效时仍执行闪避。


### PR DESCRIPTION
## 关联 Issue

Fixes #354

## 变更摘要

- 修复自动闪避开关、仅闪避模式及阈值配置相互覆盖的问题
- 支持仅闪避模式：闪避与反击提示均执行闪避
- 根据归一化置信度处理闪避、反击同时命中的情况
- 串行发送 MAA reverse RPC，避免并发响应串线导致按键失效
- 将声音检测间隔由 100ms 优化至 50ms
- 调整动作冷却计时点，避免有效触发被重复冷却丢弃
- 将闪避第二次按键间隔限制为随机 100–200ms
- 更新自动闪避功能文档

## Summary by Sourcery

改进声音闪避配置处理方式，并基于音频检测稳定闪避/反击触发行为。

New Features:
- 新增通过专用配置节点来配置声音闪避启用状态、模式和阈值的支持，并提供仅闪避模式选项。

Bug Fixes:
- 修复自动闪避开关、仅闪避模式与阈值参数之间的冲突，避免它们互相覆盖。
- 对反向 RPC 闪避/反击动作进行序列化，防止并发响应导致按键触发失败。
- 修正闪避/反击冷却计时，避免有效触发被过早丢弃。

Enhancements:
- 当两个音频事件同时命中时，通过比较置信度分数来规范闪避与反击的决策。
- 通过短轮询循环队列化并处理声音触发的动作，以提升响应速度和可靠性。
- 通过缩短监听间隔提高声音检测频率，并将闪避按键触发时间调整为更紧凑的二次按下时间窗口。

Documentation:
- 更新中文声音闪避文档，以反映新的配置节点用法以及针对反击音效的仅闪避行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve sound dodge configuration handling and stabilize dodge/counter trigger behavior based on audio detection.

New Features:
- Add support for configuring sound dodge enable, mode, and thresholds via dedicated config nodes with a dodge-only mode option.

Bug Fixes:
- Fix conflicts between auto dodge switch, dodge-only mode, and threshold parameters so they no longer override each other.
- Serialize reverse RPC dodge/counter actions to avoid concurrent responses causing keypress failures.
- Correct dodge/counter cooldown timing so valid triggers are not discarded prematurely.

Enhancements:
- Normalize dodge vs counter decisions by comparing confidence scores when both audio events hit.
- Queue and process sound-triggered actions with a short polling loop to improve responsiveness and reliability.
- Increase sound detection frequency by reducing the listening interval and adjust dodge keypress timing to a tighter second-press window.

Documentation:
- Update Chinese sound dodge documentation to reflect new config node usage and dodge-only behavior for counter sounds.

</details>