### PR TITLE
fix(Fishnew): 修复新自动钓鱼几处bug

### DIFF
--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -548,13 +548,13 @@
                 ]
             }
         },
-        "post_wait_freezes": 500,
+        "post_delay": 1000,
         "action": "Click",
         "next": [
             "[JumpBack]SceneClickBlankToExit",
-            "FishNewExitStore",
+            "FishNewSellFishEntrance",
             "FishNewConfirmBuyBait",
-            "FishNewSellFishEntrance"
+            "FishNewExitStore"
         ],
         "on_error": [
             "[Anchor]FishNewErrorRestart"

--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -555,7 +555,7 @@
             "FishNewSellFishEntrance",
             "FishNewConfirmBuyBait",
             "FishNewExitStore"
-        ],
+        ],//购买的鱼饵数量较少时不会弹出确认界面
         "on_error": [
             "[Anchor]FishNewErrorRestart"
         ]

--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -548,8 +548,11 @@
                 ]
             }
         },
+        "post_wait_freezes": 500,
         "action": "Click",
         "next": [
+            "[JumpBack]SceneClickBlankToExit",
+            "FishNewExitStore",
             "FishNewConfirmBuyBait",
             "FishNewSellFishEntrance"
         ],

--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -63,7 +63,11 @@
             70 // F
         ],
         "next": [
-            "FishNewGaming"
+            "FishNewGaming",
+            "FishNewFishHooked"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
         ]
     },
     "FishNewGaming": {
@@ -226,6 +230,9 @@
         "next": [
             "FishNewChooseGeneralBait"
             // "[JumpBack]FishNewBaitScrollMouse"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
         ]
     },
     "FishNewChooseGeneralBait": {
@@ -247,6 +254,9 @@
             "FishNewUseBait",
             "FishNewGotoBuyBait",
             "FishNewBaitExit"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
         ]
     },
     "FishNewBaitDetail": {
@@ -366,6 +376,9 @@
         },
         "next": [
             "FishNewOnStore"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
         ]
     },
     "FishNewOnStore": {
@@ -447,6 +460,9 @@
         "next": [
             "FishNewStoreChooseMaxSuccess",
             "[JumpBack]FishNewStoreChooseMax"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
         ]
     },
     "FishNewStoreScrollMouse": {
@@ -526,6 +542,9 @@
         ],
         "next": [
             "FishNewStoreBuyBait"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
         ]
     },
     "FishNewStoreBuyBait": {

--- a/assets/resource/base/pipeline/Fish/FishScene.json
+++ b/assets/resource/base/pipeline/Fish/FishScene.json
@@ -25,7 +25,7 @@
                 ]
             }
         },//识别是否在大世界钓鱼点旁边
-        "post_wait_freezes": 500,
+        "post_delay": 500,
         "action": {
             "type": "Custom",
             "param": {

--- a/assets/resource/base/pipeline/Fish/FishScene.json
+++ b/assets/resource/base/pipeline/Fish/FishScene.json
@@ -8,17 +8,28 @@
     },
     "FishSceneWorldToPrepare": {
         "desc": "从大世界进入钓鱼准备界面",
-        "recognition": "And",
-        "all_of": [
-            "FishSceneInWorldNextToFish"
-        ],
-        "post_delay": 1000,
-        "action": {
-            "type": "ClickKey",
+        "recognition": {
+            "type": "OCR",
             "param": {
-                "key": [
-                    70
+                "roi": [
+                    726,
+                    326,
+                    182,
+                    127
+                ],
+                "expected": [
+                    "钓鱼",
+                    "釣魚",
+                    "Fishing",
+                    "釣り"
                 ]
+            }
+        },//识别是否在大世界钓鱼点旁边
+        "post_wait_freezes": 500,
+        "action": {
+            "type": "Custom",
+            "param": {
+                "custom_action": "alt_click"
             }
         }
     },
@@ -34,7 +45,7 @@
         "rate_limit": 0,
         "next": [
             "FishScenePrepareToStore",
-            "FishScenePrepareToFishGame"
+            "FishScenePrepareToFishGameGo"
         ]
     },
     "FishScenePrepareToFishGame": {
@@ -50,7 +61,7 @@
         ]
     },
     "FishScenePrepareToFishGameGo": {
-        "desc": "从钓鱼准备界面进入钓鱼游戏界面 (old钓鱼)",
+        "desc": "从钓鱼准备界面进入钓鱼游戏界面",
         "recognition": "And",
         "all_of": [
             "FishSceneOnFishPrepare",
@@ -282,8 +293,7 @@
         "action": "Click",
         "next": [
             "FishNewSeaAnglerToFishMarket"
-        ]
-    ,
+        ],
         "roi_offset": [
             0,
             0,
@@ -309,8 +319,7 @@
         "action": "Click",
         "next": [
             "FishNewSellFishStart"
-        ]
-    ,
+        ],
         "roi_offset": [
             0,
             0,


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

1.因"一起去钓鱼"选项出现导致原本用按下F从大世界进入钓鱼失败
<img width="371" height="171" alt="image" src="https://github.com/user-attachments/assets/9ae14bba-27ca-4d6a-ab40-8efd4a1c466e" />

2.在商店购买鱼饵时，当可购买最大鱼饵数量过少时不会弹出确认，脚本没有相关处理
3.鱼上钩收杆有概率因未知原因失败

## 变更摘要

1.大世界进入钓鱼改用alt_click点击钓鱼按键
2.FishNewStoreBuyBait的next增加跳过识别确认界面的路径
3.FishNewFishHooked节点next增加指向自己的路径以重复执行直到进入钓鱼游戏界面
4.优化了fishscene内一处节点邻接关系
5.几个节点新增on_error兜底

## 验证

在本地测试没有遇到问题
- [ ] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

## Summary by Sourcery

修复从主世界进入并购买鱼饵时，在新的自动钓鱼流程中的问题，同时让钓鱼场景管线更加直观。

Bug Fixes:
- 确保从主世界进入钓鱼时使用备用输入方式，以避免与现有交互产生冲突。
- 处理在购买少量鱼饵时的边缘情况，确保流程能正确完成且不会遗漏确认步骤。

Enhancements:
- 调整钓鱼场景管线图，使在新的钓鱼流程中各节点之间的切换更加直观。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix issues in the new auto-fishing flow when entering from the overworld and purchasing bait, while making the fishing scene pipeline more intuitive.

Bug Fixes:
- Ensure entering fishing from the overworld uses an alternate input to avoid conflicts with existing interactions.
- Handle edge cases when purchasing small quantities of bait so the flow completes correctly without missing confirmations.

Enhancements:
- Adjust the fishing scene pipeline graph to make node transitions more intuitive during the new fishing flow.

</details>