### PR TITLE
fix(Navi): 修复在线地图导航配置不生效

### DIFF
--- a/agent/custom/action/Navi/online_map_navigation_action.py
+++ b/agent/custom/action/Navi/online_map_navigation_action.py
@@ -5,7 +5,6 @@ from maa.context import Context
 from maa.custom_action import CustomAction
 
 from ..Common.logger import get_logger
-from .waypoint_navigator import load_params
 from .route_websocket_service import RouteWebSocketService
 from .route_runner import RouteRunner
 from .route_model import RouteSession
@@ -19,8 +18,7 @@ class OnlineMapNavigationAction(CustomAction):
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
         try:
-            params = load_params(argv.custom_action_param)
-            params.update(self.load_option_params(context))
+            params = self.load_option_params(context)
             port = int(params.get("port", 14514))
             tolerance = float(params.get("tolerance", 5.0))
             frame_interval = max(0.05, float(params.get("frame_interval", 0.1)))
@@ -68,18 +66,39 @@ class OnlineMapNavigationAction(CustomAction):
     def load_option_params(context: Context) -> dict[str, Any]:
         params: dict[str, Any] = {}
 
-        node_data = context.get_node_data("OnlineMapNavigationAngleBackendConfig") or {}
-        attach = node_data.get("attach")
-        if isinstance(attach, dict) and attach.get("angle_backend") in {
+        settings = OnlineMapNavigationAction.load_config_attach(
+            context, "OnlineMapNavigationSettingsConfig"
+        )
+        for key in ("port", "tolerance", "frame_interval"):
+            if key in settings:
+                params[key] = settings[key]
+
+        position = OnlineMapNavigationAction.load_config_attach(
+            context, "OnlineMapNavigationPositionBackendConfig"
+        )
+        if position.get("position_backend") in {"auto", "coordinate", "map"}:
+            params["position_backend"] = position["position_backend"]
+
+        angle = OnlineMapNavigationAction.load_config_attach(
+            context, "OnlineMapNavigationAngleBackendConfig"
+        )
+        if angle.get("angle_backend") in {
             "auto",
             "directml",
             "cpu",
         }:
-            params["angle_backend"] = attach["angle_backend"]
+            params["angle_backend"] = angle["angle_backend"]
 
-        node_data = context.get_node_data("OnlineMapNavigationDebugConfig") or {}
-        attach = node_data.get("attach")
-        if isinstance(attach, dict) and "debug" in attach:
-            params["debug"] = attach["debug"]
+        debug = OnlineMapNavigationAction.load_config_attach(
+            context, "OnlineMapNavigationDebugConfig"
+        )
+        if "debug" in debug:
+            params["debug"] = debug["debug"]
 
         return params
+
+    @staticmethod
+    def load_config_attach(context: Context, node_name: str) -> dict[str, Any]:
+        node_data = context.get_node_data(node_name) or {}
+        attach = node_data.get("attach")
+        return attach if isinstance(attach, dict) else {}

--- a/assets/resource/base/pipeline/OnlineMapNavigation.json
+++ b/assets/resource/base/pipeline/OnlineMapNavigation.json
@@ -1,11 +1,19 @@
 {
     "OnlineMapNavigation": {
         "action": "Custom",
-        "custom_action": "online_map_navigation",
-        "custom_action_param": {
+        "custom_action": "online_map_navigation"
+    },
+    "OnlineMapNavigationSettingsConfig": {
+        "enabled": false,
+        "attach": {
             "port": 14514,
             "tolerance": 5,
-            "frame_interval": "0.1",
+            "frame_interval": "0.1"
+        }
+    },
+    "OnlineMapNavigationPositionBackendConfig": {
+        "enabled": false,
+        "attach": {
             "position_backend": "auto"
         }
     },

--- a/assets/resource/tasks/OnlineMapNavigation.json
+++ b/assets/resource/tasks/OnlineMapNavigation.json
@@ -46,8 +46,8 @@
                 }
             ],
             "pipeline_override": {
-                "OnlineMapNavigation": {
-                    "custom_action_param": {
+                "OnlineMapNavigationSettingsConfig": {
+                    "attach": {
                         "port": "{port}",
                         "tolerance": "{tolerance}",
                         "frame_interval": "{frame_interval}"
@@ -64,8 +64,8 @@
                     "name": "auto",
                     "label": "$task_online_map_navigation_position_backend_auto",
                     "pipeline_override": {
-                        "OnlineMapNavigation": {
-                            "custom_action_param": {
+                        "OnlineMapNavigationPositionBackendConfig": {
+                            "attach": {
                                 "position_backend": "auto"
                             }
                         }
@@ -75,8 +75,8 @@
                     "name": "coordinate",
                     "label": "$task_online_map_navigation_position_backend_coordinate",
                     "pipeline_override": {
-                        "OnlineMapNavigation": {
-                            "custom_action_param": {
+                        "OnlineMapNavigationPositionBackendConfig": {
+                            "attach": {
                                 "position_backend": "coordinate"
                             }
                         }
@@ -86,8 +86,8 @@
                     "name": "map",
                     "label": "$task_online_map_navigation_position_backend_map",
                     "pipeline_override": {
-                        "OnlineMapNavigation": {
-                            "custom_action_param": {
+                        "OnlineMapNavigationPositionBackendConfig": {
+                            "attach": {
                                 "position_backend": "map"
                             }
                         }

--- a/docs/zh_cn/introduction/NaviWebSocket.md
+++ b/docs/zh_cn/introduction/NaviWebSocket.md
@@ -4,18 +4,36 @@
 
 ```json
 {
-  "OnlineMapNavigation": {
-    "action": "Custom",
-    "custom_action": "online_map_navigation",
-    "custom_action_param": {
-      "port": 14514,
-      "tolerance": 5,
-      "frame_interval": "0.1",
-      "position_backend": "auto",
-      "debug": false,
-      "angle_backend": "auto"
+    "OnlineMapNavigation": {
+        "action": "Custom",
+        "custom_action": "online_map_navigation"
+    },
+    "OnlineMapNavigationSettingsConfig": {
+        "enabled": false,
+        "attach": {
+            "port": 14514,
+            "tolerance": 5,
+            "frame_interval": "0.1"
+        }
+    },
+    "OnlineMapNavigationPositionBackendConfig": {
+        "enabled": false,
+        "attach": {
+            "position_backend": "auto"
+        }
+    },
+    "OnlineMapNavigationAngleBackendConfig": {
+        "enabled": false,
+        "attach": {
+            "angle_backend": "auto"
+        }
+    },
+    "OnlineMapNavigationDebugConfig": {
+        "enabled": false,
+        "attach": {
+            "debug": false
+        }
     }
-  }
 }
 ```
 
@@ -33,22 +51,22 @@ ws://127.0.0.1:14514
 
 ```json
 {
-  "type": "navi-state",
-  "version": 1,
-  "position": {
-    "x": -134394.56,
-    "y": 199913.53,
-    "z": 11416.17,
-    "pixelX": 4090,
-    "pixelY": 6750,
-    "sourceWidth": 11264,
-    "sourceHeight": 11264,
-    "score": 1.0,
-    "mode": "coordinate"
-  },
-  "angle": 123.4,
-  "angleConfidence": 0.96,
-  "timestamp": 1770000000.0
+    "type": "navi-state",
+    "version": 1,
+    "position": {
+        "x": -134394.56,
+        "y": 199913.53,
+        "z": 11416.17,
+        "pixelX": 4090,
+        "pixelY": 6750,
+        "sourceWidth": 11264,
+        "sourceHeight": 11264,
+        "score": 1.0,
+        "mode": "coordinate"
+    },
+    "angle": 123.4,
+    "angleConfidence": 0.96,
+    "timestamp": 1770000000.0
 }
 ```
 


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

暂无关联 Issue。

需求来源：用户反馈修改 `OnlineMapNavigation` 监听端口后仍使用默认端口 `14514`。定位后端选项覆盖了同一节点的 `custom_action_param`，导致端口等设置丢失。

## 变更摘要

- 将端口、容差和帧间隔迁移至独立的 `OnlineMapNavigationSettingsConfig` attach 节点
- 将定位后端迁移至独立的 `OnlineMapNavigationPositionBackendConfig` attach 节点
- 统一通过 attach 配置节点读取定位后端、角度后端和调试设置
- 移除 `OnlineMapNavigation` 对 `custom_action_param` 的旧读取路径
- 同步更新 Navi WebSocket 开发文档

## 验证

- [x] 使用 `python -m py_compile agent/custom/action/Navi/online_map_navigation_action.py` 完成 Python 语法检查
- [x] 解析 `OnlineMapNavigation` 任务及 Pipeline JSON，确认格式有效
- [x] 检查所有任务选项均写入独立 attach 配置节点，不再覆盖执行节点参数
- [x] 使用 Prettier 检查修改的 JSON 和 Markdown 文件
- [x] 使用 `git diff --check` 检查空白字符
- [x] 使用 Win32-Front 控制器完整运行在线地图导航任务

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

修复前将端口设置为 `12345` 后，运行时仍回退至默认端口 `14514`：

```text
Navigation WebSocket failed to start: [Errno 13] error while attempting to bind on address ('0.0.0.0', 14514): [WinError 10013]
Navigation WebSocket stopped: ws://0.0.0.0:14514
OnlineMapNavigation failed: Navigation WebSocket failed to start: ws://0.0.0.0:14514
```

## Summary by Sourcery

修复 OnlineMapNavigation，使其仅从专用的 attach 配置节点中读取导航设置，而不再使用 custom_action_param。

错误修复：
- 确保 OnlineMapNavigation 使用已配置的 WebSocket 端口、公差和帧间隔，而不是在静默情况下回退到默认值。

增强功能：
- 为 OnlineMapNavigation 设置、位置后端、角度后端和调试选项引入专用的 attach 配置节点，并在动作实现中集中其加载逻辑。

文档：
- 更新 Navi WebSocket 文档，以反映新的 OnlineMapNavigation 配置结构，即使用单独的 attach 配置节点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix OnlineMapNavigation so that navigation settings are read exclusively from dedicated attach configuration nodes instead of custom_action_param.

Bug Fixes:
- Ensure OnlineMapNavigation uses configured WebSocket port, tolerance, and frame interval instead of silently falling back to the default values.

Enhancements:
- Introduce dedicated attach config nodes for OnlineMapNavigation settings, position backend, angle backend, and debug options, and centralize their loading logic in the action implementation.

Documentation:
- Update Navi WebSocket documentation to reflect the new OnlineMapNavigation configuration structure using separate attach config nodes.

</details>