### PR TITLE
feat(FishNew):新增一个custom action替换alt_click,修复新钓鱼在桌面端-默认、桌面端-后台无法从大世界进入钓鱼游戏界面的问题

### DIFF
--- a/agent/custom/action/AutoFish/enter_fishprepare.py
+++ b/agent/custom/action/AutoFish/enter_fishprepare.py
@@ -1,0 +1,71 @@
+"""从大世界进入钓鱼准备界面。
+通过 OCR 识别"钓鱼"选项的坐标，
+按下 Alt → 光标移到选项 → 松 Alt → 按 F 进入钓鱼准备界面。
+这是可以在后台使用的，在大世界钓鱼旁边选择钓鱼选项进入的操作。
+"""
+
+import time
+
+from maa.agent.agent_server import AgentServer
+from maa.custom_action import CustomAction
+from maa.context import Context
+from maa.pipeline import JOCR, JRecognitionType
+
+from utils.logger import logger
+
+# 钓鱼选项 OCR 搜索区域
+OPTION_ROI = [726, 326, 182, 127]
+# 多语言匹配
+OPTION_TEXTS = ["钓鱼", "釣魚", "Fishing", "釣り"]
+
+
+@AgentServer.custom_action("enter_fishprepare")
+class EnterFishPrepare(CustomAction):
+    def run(
+        self, context: Context, argv: CustomAction.RunArg
+    ) -> CustomAction.RunResult:
+        controller = context.tasker.controller
+
+        # ① 截图
+        image = controller.post_screencap().wait().get()
+
+        # ② OCR 识别"钓鱼"选项位置
+        ocr = context.run_recognition_direct(
+            JRecognitionType.OCR,
+            JOCR(roi=OPTION_ROI, expected=OPTION_TEXTS),
+            image,
+        )
+        if not ocr or not ocr.hit or not ocr.box:
+            logger.debug("enter_fishprepare: 未识别到钓鱼选项")
+            return CustomAction.RunResult(success=False)
+
+        x, y, w, h = ocr.box
+        logger.debug("enter_fishprepare: 钓鱼选项位置 (%d, %d, %d, %d)", x, y, w, h)
+
+        # ③ 按下 Alt
+        context.run_action("__AltClickAltKeyDownAction")
+        time.sleep(0.05)
+
+        # ④ Pipeline TouchMove 挪光标（不点击）
+        context.run_action(
+            "_enter_fishprepare_move",
+            pipeline_override={
+                "_enter_fishprepare_move": {
+                    "action": {"type": "TouchMove", "param": {"target": [x, y, w, h]}},
+                },
+            },
+        )
+        time.sleep(0.2)
+        logger.debug("enter_fishprepare: 光标移到 (%d, %d, %d, %d)", x, y, w, h)
+
+        # ⑤ 松开 Alt
+        context.run_action("__AltClickAltKeyUpAction")
+        time.sleep(0.05)
+
+        # ⑥ 按 F 进入
+        controller.post_key_down(0x46).wait()
+        time.sleep(0.03)
+        controller.post_key_up(0x46).wait()
+
+        logger.debug("enter_fishprepare: 完成")
+        return CustomAction.RunResult(success=True)

--- a/agent/custom/action/__init__.py
+++ b/agent/custom/action/__init__.py
@@ -23,6 +23,7 @@ from .auto_f_scroll import *
 from .Movement.mouse_move import *
 from .Movement.character_move import *
 from .Common.alt_click import *
+from .AutoFish.enter_fishprepare import *
 from .Furniture.furniture_claim import *
 from .Furniture.furniture_choose_property import *
 from .auto_piano.action import *
@@ -63,6 +64,7 @@ __all__ = [
     "SoundDodgeAction",
     "AutoFScroll",
     "AltClick",
+    "EnterFishPrepare",
     "FurnitureClaim",
     "FurnitureChooseProperty",
     "AutoPlayPiano",

--- a/assets/resource/base/pipeline/Fish/FishScene.json
+++ b/assets/resource/base/pipeline/Fish/FishScene.json
@@ -8,28 +8,15 @@
     },
     "FishSceneWorldToPrepare": {
         "desc": "从大世界进入钓鱼准备界面",
-        "recognition": {
-            "type": "OCR",
-            "param": {
-                "roi": [
-                    726,
-                    326,
-                    182,
-                    127
-                ],
-                "expected": [
-                    "钓鱼",
-                    "釣魚",
-                    "(?i)Fishing",
-                    "釣り"
-                ]
-            }
-        },//识别是否在大世界钓鱼点旁边
-        "post_delay": 500,
+        "recognition": "And",
+        "all_of": [
+            "FishSceneInWorldNextToFish"
+        ],
+        "post_delay": 1000,
         "action": {
             "type": "Custom",
             "param": {
-                "custom_action": "alt_click"
+                "custom_action": "enter_fishprepare"//用一种适配后台的方法进入钓鱼准备界面
             }
         }
     },


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

## 变更摘要

custom action具体操作为：识别钓鱼选项位置，按下alt，鼠标挪动到选项位置（不按下），松开alt，按下F进入钓鱼准备界面
替换掉FishSceneWorldToPrepare的alt_click

## 验证

在本地电脑上测试，默认、前台、后台均可正常运行

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## Summary by Sourcery

添加一个自定义动作，用于从开放世界中稳定地进入新的钓鱼准备界面，取代之前基于 Alt-点击 的流程。

New Features:
- 引入 `EnterFishPrepare` 自定义动作，使用 OCR 定位“钓鱼”选项，并模拟 Alt + F 输入以进入钓鱼准备界面。

Enhancements:
- 将 `EnterFishPrepare` 自定义动作接入自定义动作注册表，以便在与钓鱼相关的流水线中使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a custom action to reliably enter the new fishing preparation screen from the open world, replacing the previous Alt-click based flow.

New Features:
- Introduce the EnterFishPrepare custom action that uses OCR to locate the fishing option and simulate Alt plus F input to enter the fishing preparation screen.

Enhancements:
- Wire the EnterFishPrepare custom action into the custom action registry for use in fishing-related pipelines.

</details>