### PR TITLE
Feat(Navi): 在pcap不可用的时候自动切换到pktmon后端

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -462,8 +462,6 @@ assets/resource/base/model/detect/limbo_stage_lightest.onnx
 assets/resource/base/model/detect/sos_nodes.onnx
 .claude/
 .nicegui/
-tools/pktmon_coordinate_backend
-tools/demo_coordinate_capture.py
 
 # local gui test
 MFA/

--- a/.gitignore
+++ b/.gitignore
@@ -462,6 +462,8 @@ assets/resource/base/model/detect/limbo_stage_lightest.onnx
 assets/resource/base/model/detect/sos_nodes.onnx
 .claude/
 .nicegui/
+tools/pktmon_coordinate_backend
+tools/demo_coordinate_capture.py
 
 # local gui test
 MFA/

--- a/agent/custom/action/Navi/coordinate_position.py
+++ b/agent/custom/action/Navi/coordinate_position.py
@@ -40,6 +40,23 @@ class _CoordinateCapture(Protocol):
     def close(self) -> None: ...
 
 
+def _ensure_packet_capture_provider_available() -> None:
+    try:
+        from scapy.config import conf
+    except ImportError as exc:
+        raise RuntimeError(
+            "Scapy is required for network coordinate capture"
+        ) from exc
+
+    conf.use_pcap = True
+    if conf.use_pcap:
+        return
+    raise RuntimeError(
+        "Scapy did not find a libpcap provider; "
+        "network coordinate capture is unavailable"
+    )
+
+
 def _create_capture() -> _CoordinateCapture:
     if not _THIRDPARTY_DIR.is_dir():
         raise RuntimeError("coordinate core directory not found: %s" % _THIRDPARTY_DIR)
@@ -192,6 +209,7 @@ class CoordinatePositionProvider:
 
         capture: _CoordinateCapture | None = None
         try:
+            _ensure_packet_capture_provider_available()
             capture = _create_capture()
             capture.start()
         except Exception as exc:

--- a/agent/custom/action/Navi/coordinate_position.py
+++ b/agent/custom/action/Navi/coordinate_position.py
@@ -20,7 +20,8 @@ _CORE_MODULE = "nte_coordinate_api"
 _CORE_FILENAME = "nte_coordinate_api.cp312-win_amd64.pyd"
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 _THIRDPARTY_DIR = _PROJECT_ROOT / "thirdparty"
-_API_VERSION = "1.1.1"
+_API_VERSION = "1.2.0"
+_COORDINATE_SAMPLE_MAX_AGE = 1.0
 
 # BEGIN GENERATED NAVI COORDINATE TRANSFORM
 _CALIBRATION_AXES = (0, 1)
@@ -37,27 +38,12 @@ class _CoordinateCapture(Protocol):
 
     def read(self, max_age: float = 1.0) -> _RawPose | None: ...
 
+    def stats(self) -> dict[str, Any]: ...
+
     def close(self) -> None: ...
 
 
-def _ensure_packet_capture_provider_available() -> None:
-    try:
-        from scapy.config import conf
-    except ImportError as exc:
-        raise RuntimeError(
-            "Scapy is required for network coordinate capture"
-        ) from exc
-
-    conf.use_pcap = True
-    if conf.use_pcap:
-        return
-    raise RuntimeError(
-        "Scapy did not find a libpcap provider; "
-        "network coordinate capture is unavailable"
-    )
-
-
-def _create_capture() -> _CoordinateCapture:
+def _create_capture(capture_backend: str) -> _CoordinateCapture:
     if not _THIRDPARTY_DIR.is_dir():
         raise RuntimeError("coordinate core directory not found: %s" % _THIRDPARTY_DIR)
     thirdparty_path = str(_THIRDPARTY_DIR)
@@ -66,9 +52,9 @@ def _create_capture() -> _CoordinateCapture:
 
     candidate = _THIRDPARTY_DIR / _CORE_FILENAME
     loaded_module = sys.modules.get(_CORE_MODULE)
-    if loaded_module is not None and Path(
-        str(getattr(loaded_module, "__file__", ""))
-    ) == candidate:
+    if loaded_module is not None and callable(
+        getattr(loaded_module, "CoordinateCapture", None)
+    ):
         module = loaded_module
     else:
         if not candidate.exists():
@@ -112,7 +98,7 @@ def _create_capture() -> _CoordinateCapture:
             % (api_version or "<unknown>")
         )
 
-    capture = capture_type(refresh_rate=0)
+    capture = capture_type(refresh_rate=0, capture_backend=capture_backend)
     for method_name in ("start", "read", "close"):
         if not callable(getattr(capture, method_name, None)):
             raise RuntimeError(
@@ -197,6 +183,7 @@ class CoordinatePositionProvider:
         if normalized not in {"map", "auto", "coordinate"}:
             raise ValueError("position_backend must be map, auto, or coordinate")
         self._capture: _CoordinateCapture | None = None
+        self._capture_backend: str | None = None
         self._coordinate_active = False
         self._debug = bool(debug)
         self._last_map_point: _MapPoint | None = None
@@ -207,22 +194,42 @@ class CoordinatePositionProvider:
         if normalized == "map":
             return
 
-        capture: _CoordinateCapture | None = None
-        try:
-            _ensure_packet_capture_provider_available()
-            capture = _create_capture()
-            capture.start()
-        except Exception as exc:
-            if capture is not None:
-                capture.close()
+        errors: list[tuple[str, str]] = []
+        for capture_backend in ("pcap", "pktmon"):
+            capture: _CoordinateCapture | None = None
+            try:
+                capture = _create_capture(capture_backend)
+                capture.start()
+            except Exception as exc:
+                if capture is not None:
+                    capture.close()
+                errors.append((capture_backend, str(exc)))
+                logger.warning(
+                    "Navi coordinate backend unavailable: backend=%s reason=%s",
+                    capture_backend,
+                    exc,
+                )
+                continue
+
+            self._capture = capture
+            self._capture_backend = capture_backend
+            break
+
+        if self._capture is None:
+            detail = (
+                "; ".join("%s: %s" % (name, reason) for name, reason in errors)
+                or "no coordinate capture backend attempted"
+            )
             if normalized == "coordinate":
-                raise
-            logger.warning("Navi coordinate capture unavailable, using map: %s", exc)
+                raise RuntimeError("Navi coordinate capture unavailable: %s" % detail)
+            logger.warning(
+                "Navi coordinate backends unavailable; using visual positioning"
+            )
             return
 
-        self._capture = capture
         logger.info(
-            "Navi coordinate capture started: axes=%s scale=%.9f error=%.2f",
+            "Navi coordinate capture started: backend=%s axes=%s scale=%.9f error=%.2f",
+            self._capture_backend,
             _COORDINATE_TRANSFORM.axes,
             math.hypot(_COORDINATE_TRANSFORM.a, _COORDINATE_TRANSFORM.b),
             _COORDINATE_TRANSFORM.error,
@@ -238,10 +245,17 @@ class CoordinatePositionProvider:
                 result.raw_coordinate = _raw_xy_from_map(result.point)
             return result
 
-        pose = capture.read()
+        pose = capture.read(max_age=_COORDINATE_SAMPLE_MAX_AGE)
         if pose is None:
             if self._debug:
-                logger.debug("Navi coordinate unavailable; source=coordinate")
+                logger.debug(
+                    "Navi coordinate unavailable; source=coordinate stats=%s",
+                    (
+                        capture.stats()
+                        if callable(getattr(capture, "stats", None))
+                        else {}
+                    ),
+                )
             return MapLocationResult(
                 found=False,
                 point=self._last_map_point,

--- a/docs/zh_cn/develop/local-route-navigation.md
+++ b/docs/zh_cn/develop/local-route-navigation.md
@@ -78,7 +78,7 @@
 | `tolerance` | float | `5.0` | 到达判定距离。当前位置到目标点距离小于等于该值时认为到达。 |
 | `frame_interval` | float | `0.1` | 视觉模式的导航、截图、定位和方向推理间隔，最低会限制为 `0.05` 秒。网络姿态模式固定使用 60 Hz 控制循环。 |
 | `angle_backend` | string | `"auto"` | 方向模型推理后端。常用值：`auto`、`directml`、`cpu`。 |
-| `position_backend` | string | `"auto"` | 位置来源。`map` 使用小地图匹配和视觉方向模型；`auto` 优先使用网络位置与摄像机朝向，网络核心无法启用时回退完整视觉方案；`coordinate` 严格要求 1.1 网络核心可用。 |
+| `position_backend` | string | `"auto"` | 位置来源。`map` 使用小地图匹配和视觉方向模型；`auto` 优先使用网络位置与摄像机朝向，并按 pcap、pktmon、视觉定位顺序回退；`coordinate` 严格要求网络核心可用。 |
 | `debug` | bool | `false` | 是否打开定位和方向预测调试窗口，并输出原始网络坐标、映射坐标及定位来源日志。 |
 
 CustomAction 返回 `success=True` 表示该 segment 跑到终点；参数错误、路线为空、运行异常或任务停止会返回失败。
@@ -218,7 +218,7 @@ navigator.close()
 
 - 长路线拆成多个 segment 时，Pipeline 入口适合一次跑一个 segment；Python 内部连续跑多个 segment 时用 `LocalRouteNavigation` 类复用资源。
 - `tolerance` 太小会导致角色在目标点附近反复调整；地图定位误差较大时应适当增大。
-- `position_backend=coordinate` 依赖 Scapy 和系统抓包驱动。网络定位成功启用后，位置与摄像机朝向均使用 1.1 核心 `read()` 的网络数据，不再初始化小地图视觉定位或 `AnglePredictor`，也不会为这两项功能额外截图。Navi 以 `CoordinateCapture(refresh_rate=0)` 启动核心，不限制样本发布刷新率，并以 60 Hz 运行导航控制循环。网络样本暂时中断时位置状态为 `coordinate_stale`，不会回退视觉。`auto` 模式仅在网络核心启动失败时使用完整视觉方案。
+- `position_backend=coordinate` 依赖网络抓包后端。启动时优先使用 Scapy + libpcap（Npcap/WinPcap），不可用时尝试 `pktmon-interface`；pktmon 后端通常需要以管理员权限运行。两者都不可用则失败；`auto` 模式在两种网络后端都启动失败时回退完整视觉方案。网络定位成功启用后，位置与摄像机朝向均使用 1.2 核心 `read()` 的网络数据，不再初始化小地图视觉定位或 `AnglePredictor`，也不会为这两项功能额外截图。Navi 以 `CoordinateCapture(refresh_rate=0, capture_backend=...)` 启动核心，不限制样本发布刷新率，并以 60 Hz 运行导航控制循环。网络样本暂时中断时位置状态为 `coordinate_stale`，不会回退视觉。
 - WebSocket 位置统一使用游戏原始坐标。网络定位发送 `x/y/z`，并通过顶层 `angle`、`pitch` 发送映射后的水平摄像机角和原始俯仰角；视觉定位通过标定逆变换发送 `x/y`，不发送无法可靠推导的高度 `z` 或俯仰角。网络样本短暂中断时会保留最后一次位置用于地图展示，但该位置不会被导航逻辑视为有效实时位置。
 - `config/navi_coordinate_calibration.json` 仅用于本地调试计算，不会在运行时读取。修改标定点后执行 `python scripts/update_navi_coordinate_transform.py`，脚本会计算最佳变换并更新 `coordinate_position.py` 中的常量。
 - 需要手动标定时，可把该文件改为标定点格式。开启 `debug=true` 从 `Navi coordinate position/validation` 日志读取 `raw` 网络坐标，并在地图上取得对应的 11264×11264 像素坐标。至少填写 3 个相距较远且不共线的点：
@@ -244,7 +244,7 @@ navigator.close()
 ```
 
 每个点可填写 `map: [pixelX, pixelY]`，也可直接填写在线地图坐标 `world: [lat, lng]`。启动时会自动选择原始三维坐标中的运动平面并拟合旋转、缩放和平移。建议使用 4～8 个覆盖路线区域的点；日志中的 `error` 是拟合后的地图像素均方根误差。
-- 坐标抓取核心不属于 Agent 源码。加密产物放在项目根目录 `thirdparty/`，并提供可导入的 `nte_coordinate_api` 模块。模块公开 `CoordinateCapture` 类及其 `start()`、`read(max_age=1.0)`、`close()` 方法。`CoordinateCapture(refresh_rate=30.0)` 可设置每秒发布的最大样本数，默认 `30`，设为 `0` 时不限速。1.1 起 `read()` 返回同一数据包解析出的 `(x, y, z, pitch, heading)` 或 `None`，其中 `pitch` 为原始俯仰角，`heading` 为映射后的水平摄像机罗盘角（正北为 `0°`，范围 `[0, 360)`）；该返回值不兼容 1.0 的三元坐标。MXU 组装时会原样复制该目录。
+- 坐标抓取核心源码位于 `agent/custom/action/temp/nte_coordinate_api.py`，加密产物放在项目根目录 `thirdparty/`，并提供可导入的 `nte_coordinate_api` 模块。模块公开 `CoordinateCapture` 类及其 `start()`、`read(max_age=1.0)`、`close()` 方法。`CoordinateCapture(refresh_rate=30.0, capture_backend="pcap")` 可设置每秒发布的最大样本数和抓包后端，`capture_backend` 支持 `"pcap"` / `"scapy"` 和 `"pktmon"`，`refresh_rate` 设为 `0` 时不限速。1.1 起 `read()` 返回同一数据包解析出的 `(x, y, z, pitch, heading)` 或 `None`，其中 `pitch` 为原始俯仰角，`heading` 为映射后的水平摄像机罗盘角（正北为 `0°`，范围 `[0, 360)`）；该返回值不兼容 1.0 的三元坐标。MXU 组装时会原样复制该目录。
 - PyArmor 的 `pyarmor_runtime.pyd` 与 Python ABI 绑定，必须使用最终运行环境相同的 Python 主次版本和架构生成。当前发布环境目标为 Python 3.12 x64，不能使用 Python 3.10、3.13 或 3.14 生成的 runtime。
 - `debug=true` 会打开 OpenCV 调试窗口，只用于本地调试。
 - 路线执行依赖实时截图、地图定位和方向模型，不能在没有 Maa `Context` 和控制器的普通单元测试里完整运行。

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ scikit-learn
 soundcard
 mido
 scapy
+pktmon-interface
 websockets>=14.0,<17.0

--- a/tools/demo_coordinate_capture.py
+++ b/tools/demo_coordinate_capture.py
@@ -29,15 +29,14 @@ def load_coordinate_module() -> Any:
     _ensure_project_paths()
     candidate = THIRDPARTY_DIR / MODULE_FILENAME
     loaded_module = sys.modules.get(MODULE_NAME)
-    if loaded_module is not None and Path(
-        str(getattr(loaded_module, "__file__", ""))
-    ) == candidate:
+    if (
+        loaded_module is not None
+        and Path(str(getattr(loaded_module, "__file__", ""))) == candidate
+    ):
         return loaded_module
 
     if not candidate.exists():
-        raise FileNotFoundError(
-            "No coordinate module found: %s" % candidate
-        )
+        raise FileNotFoundError("No coordinate module found: %s" % candidate)
 
     spec = importlib.util.spec_from_file_location(MODULE_NAME, candidate)
     if spec is None or spec.loader is None:
@@ -108,8 +107,7 @@ def main(argv: list[str] | None = None) -> int:
             capture.start()
         except Exception as exc:
             print(
-                "failed to start coordinate capture: %s: %s"
-                % (type(exc).__name__, exc)
+                "failed to start coordinate capture: %s: %s" % (type(exc).__name__, exc)
             )
             return 1
         deadline = start + max(args.seconds, 0.0)
@@ -159,8 +157,7 @@ def main(argv: list[str] | None = None) -> int:
             capture.close()
         except Exception as exc:
             print(
-                "coordinate capture close warning: %s: %s"
-                % (type(exc).__name__, exc)
+                "coordinate capture close warning: %s: %s" % (type(exc).__name__, exc)
             )
 
     if samples == 0:


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

无关联 Issue。需求来源：本地路线导航在 pcap / Npcap / WinPcap 抓包不可用时，需要继续尝试 `pktmon` 网络坐标捕获；网络后端全部不可用时，`auto` 模式应回退视觉定位。

## 变更摘要

- 将 Navi 坐标捕获核心 API 要求更新到 `1.2.0`
- `position_backend=auto` 下按 `pcap -> pktmon -> 视觉定位` 顺序回退，`coordinate` 模式下网络后端全部不可用则直接失败
- 新增 `pktmon-interface` 依赖，用于支持 pktmon 抓包后端
- 补充本地路线导航文档，说明 pcap / pktmon 后端、管理员权限要求和 `CoordinateCapture(..., capture_backend=...)` 用法

## 验证

- [x] 执行 `python -m py_compile agent/custom/action/Navi/coordinate_position.py tools/demo_coordinate_capture.py`，语法校验通过
- [x] 执行 `git diff --check dev...HEAD`，未发现空白字符问题
- [x] 模拟pcap不可用时自动切换到pktmon抓包模式，坐标显示正常

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

本 PR 涉及网络坐标捕获后端回退逻辑，无新增 ROI 或模板图片。

## Summary by Sourcery

引入从 pcap 到 pktmon 的回退机制用于 Navi 坐标捕获，并将坐标核心集成更新到 1.2.0 API。

New Features:
- 支持通过 `pcap` 或 `pktmon` 选择坐标捕获后端，并在自动模式下提供自动回退。
- 在坐标样本不可用时暴露捕获后端统计信息以便调试。

Enhancements:
- 将 Navi 坐标 API 版本要求从 1.1.1 更新到 1.2.0，并相应调整捕获初始化流程。
- 改进与坐标后端选择、故障以及启动相关的日志记录。
- 在读取位姿时收紧坐标样本的年龄处理，以避免使用过期数据。

Build:
- 为 Navi 网络坐标后端新增 `pktmon-interface` 依赖。

Documentation:
- 扩展本地路径导航文档，涵盖 `pcap` 和 `pktmon` 后端、权限、更新后的核心 API 行为以及 `CoordinateCapture` 参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce fallback from pcap to pktmon for Navi coordinate capture and update the coordinate core integration to the 1.2.0 API.

New Features:
- Support selecting coordinate capture backend via pcap or pktmon with automatic fallback in auto mode.
- Expose capture backend statistics for debugging when coordinate samples are unavailable.

Enhancements:
- Update Navi coordinate API version requirement from 1.1.1 to 1.2.0 and adjust capture initialization accordingly.
- Improve logging around coordinate backend selection, failures, and startup.
- Tighten coordinate sample age handling when reading poses to avoid using stale data.

Build:
- Add pktmon-interface as a new dependency for the Navi network coordinate backend.

Documentation:
- Expand local route navigation documentation to cover pcap and pktmon backends, permissions, updated core API behavior, and CoordinateCapture parameters.

</details>