### PR TITLE
feat(build): 支持在 Linux/macOS 宿主机交叉组装 Windows 发行包

### DIFF
--- a/build.py
+++ b/build.py
@@ -97,16 +97,28 @@ def download(url, dest):
         raise
 
 
-def get_platform():
-    """获取当前平台信息"""
+def get_platform(target_os="auto", target_arch="auto"):
+    """获取平台信息。
+
+    target_os/target_arch 为 "auto" 时返回宿主平台（原有行为）；
+    指定目标平台（如 --target-os windows）时返回目标平台元组，
+    用于在 Linux/macOS 宿主机上交叉组装 Windows 发行包。
+    """
     os_type = platform.system()
     os_arch = platform.machine()
 
+    if target_os != "auto":
+        os_type = {"windows": "Windows", "linux": "Linux", "darwin": "Darwin"}[target_os]
+    if target_arch != "auto":
+        os_arch = target_arch
+
     # Windows ARM64 detection via PROCESSOR_IDENTIFIER
     if os_type == "Windows":
-        proc_id = os.environ.get("PROCESSOR_IDENTIFIER", "")
-        if "ARMv8" in proc_id or "ARM64" in proc_id:
-            os_arch = "ARM64"
+        # PROCESSOR_IDENTIFIER 探测仅在真实 Windows 宿主机上有意义
+        if platform.system() == "Windows" and target_arch == "auto":
+            proc_id = os.environ.get("PROCESSOR_IDENTIFIER", "")
+            if "ARMv8" in proc_id or "ARM64" in proc_id:
+                os_arch = "ARM64"
         arch_map = {"AMD64": "AMD64", "x86_64": "AMD64", "ARM64": "ARM64", "aarch64": "ARM64"}
     elif os_type == "Darwin":
         arch_map = {"x86_64": "x86_64", "arm64": "arm64", "aarch64": "arm64"}
@@ -124,6 +136,35 @@ def get_platform():
 
 
 # ========== 各步骤 ==========
+
+def _bootstrap_pip_offline(python_dir):
+    """交叉构建时无法执行目标平台的 python.exe，改用宿主 pip 下载通用 wheel 并直接解压。
+
+    pip/setuptools 均为纯 Python 包（py3-none-any 通用 wheel），wheel 本质是 zip，
+    解压到 Lib/site-packages 即完成安装；运行期通过 `python.exe -m pip` 调用，
+    不依赖 Scripts/pip.exe 启动器。
+    """
+    site_packages = python_dir / "Lib" / "site-packages"
+    site_packages.mkdir(parents=True, exist_ok=True)
+    bootstrap_dir = python_dir / "_pip_bootstrap"
+    bootstrap_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        run([
+            sys.executable, "-m", "pip", "download",
+            "pip", "setuptools",
+            "--only-binary=:all:",
+            "-d", str(bootstrap_dir),
+        ])
+        wheels = sorted(bootstrap_dir.glob("*.whl"))
+        if not wheels:
+            raise FileNotFoundError("pip bootstrap 失败：未下载到任何 whl 文件")
+        for whl in wheels:
+            print(f"  解压 {whl.name} -> {site_packages}")
+            with zipfile.ZipFile(whl) as zf:
+                zf.extractall(site_packages)
+    finally:
+        shutil.rmtree(bootstrap_dir, ignore_errors=True)
+
 
 def step_setup_python(os_type, os_arch):
     """步骤1: 安装嵌入式 Python + pip"""
@@ -222,24 +263,37 @@ def step_setup_python(os_type, os_arch):
 
     # 安装 pip
     print("  安装 pip...")
-    get_pip_url = "https://bootstrap.pypa.io/get-pip.py"
-    get_pip_path = PYTHON_DIR / "get-pip.py"
-    download(get_pip_url, get_pip_path)
-    run([str(python_exe), str(get_pip_path)])
-    get_pip_path.unlink()
+    if os_type == "Windows" and platform.system() != "Windows":
+        # 交叉构建：python.exe 无法在宿主机执行，走离线解压方式
+        _bootstrap_pip_offline(PYTHON_DIR)
+    else:
+        get_pip_url = "https://bootstrap.pypa.io/get-pip.py"
+        get_pip_path = PYTHON_DIR / "get-pip.py"
+        download(get_pip_url, get_pip_path)
+        run([str(python_exe), str(get_pip_path)])
+        get_pip_path.unlink()
 
     print(f"  Python 就绪: {python_exe}")
     return python_exe
 
 
-def step_download_python_deps(python_exe):
-    """步骤2: 下载 Python 依赖 wheel"""
+def step_download_python_deps(python_exe, pip_platform_tag=None, python_version=None):
+    """步骤2: 下载 Python 依赖 wheel
+
+    交叉构建时传入 pip_platform_tag（如 win_amd64）与目标 python_version，
+    覆盖 download_deps.py 的宿主平台自动探测。
+    """
     print("\n" + "=" * 60)
     print("[2/12] 下载 Python 依赖")
     print("=" * 60)
 
     download_script = TOOLS_DIR / "download_deps.py"
-    run([str(python_exe), str(download_script), "--deps-dir", str(PYTHON_DEPS_DIR)])
+    cmd = [str(python_exe), str(download_script), "--deps-dir", str(PYTHON_DEPS_DIR)]
+    if pip_platform_tag:
+        cmd += ["--platform-tag", pip_platform_tag]
+    if python_version:
+        cmd += ["--python-version", python_version]
+    run(cmd)
 
 
 def step_download_maa_framework(os_arch):
@@ -392,14 +446,21 @@ def step_install(python_exe, tag, platform_tag):
     # run([str(python_exe), str(install_script), tag, platform_tag])
 
 
-def step_install_mxu(python_exe, tag):
-    """步骤9: 运行 install_mxu.py 组装 MXU 安装目录"""
+def step_install_mxu(python_exe, tag, target_platform=None):
+    """步骤9: 运行 install_mxu.py 组装 MXU 安装目录
+
+    target_platform（win32/darwin/linux）用于交叉构建时指定发行包内
+    interface.json 的 child_exec 平台，缺省由 install_mxu.py 取宿主平台。
+    """
     print("\n" + "=" * 60)
     print("[9/12] 组装 MXU 安装目录")
     print("=" * 60)
 
     install_script = TOOLS_DIR / "install_mxu.py"
-    run([str(python_exe), str(install_script), tag])
+    cmd = [str(python_exe), str(install_script), tag]
+    if target_platform:
+        cmd.append(target_platform)
+    run(cmd)
 
     # 复制 Python 环境到 MXU 安装目录
     print("  复制 Python 到 install-mxu/...")
@@ -509,10 +570,11 @@ def step_package(platform_tag, tag, output_dir, mxu=False):
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    os_type = platform.system()
     pkg_name = f"MaaNTE-{platform_tag}-{tag}{variant}"
 
-    if os_type == "Windows":
+    # 压缩格式按目标平台决定（platform_tag 形如 win-x64 / linux-x64），
+    # 而非宿主平台——交叉构建时 Windows 包必须是 zip
+    if platform_tag.startswith("win"):
         pkg_path = output_dir / f"{pkg_name}.zip"
         print(f"  创建 ZIP: {pkg_path}")
         with zipfile.ZipFile(pkg_path, "w", zipfile.ZIP_DEFLATED) as zf:
@@ -552,6 +614,11 @@ def main():
                         help=f"MFAAvalonia 版本 (默认: {MFAA_VERSION})")
     parser.add_argument("--mxu-version", default=MXU_VERSION,
                         help=f"MXU 版本 (默认: {MXU_VERSION})")
+    parser.add_argument("--target-os", default="auto", choices=["auto", "windows"],
+                        help="目标操作系统 (默认: auto=宿主平台)。在 Linux/macOS 上"
+                             "指定 windows 可交叉组装 Windows 发行包")
+    parser.add_argument("--target-arch", default="auto", choices=["auto", "x86_64", "arm64"],
+                        help="目标架构 (默认: auto=宿主架构)")
 
     args = parser.parse_args()
     MAA_FRAMEWORK_VERSION = args.maa_version
@@ -571,9 +638,14 @@ def main():
         if r.returncode != 0:
             print("警告: git submodule 初始化失败，OCR 模型可能无法正确配置")
 
-    # 检测平台
-    os_type, os_arch, platform_tag = get_platform()
-    print(f"平台: {os_type} / {os_arch} / {platform_tag}")
+    # 检测平台（target-os/target-arch 非 auto 时为交叉构建目标）
+    os_type, os_arch, platform_tag = get_platform(args.target_os, args.target_arch)
+    is_cross = os_type != platform.system()
+    if is_cross and os_type != "Windows":
+        print(f"错误: 交叉构建仅支持 Windows 目标，当前目标: {os_type}")
+        sys.exit(1)
+    print(f"平台: {os_type} / {os_arch} / {platform_tag}"
+          + (f"  [交叉构建，宿主: {platform.system()}]" if is_cross else ""))
     print(f"版本: {args.tag}")
     print(f"输出: {args.output_dir}")
     print(f"MaaFramework: {MAA_FRAMEWORK_VERSION}")
@@ -585,8 +657,18 @@ def main():
         # 1. 嵌入式 Python
         python_exe = step_setup_python(os_type, os_arch)
 
+        # 交叉构建时目标 python.exe 无法在宿主机执行，工具脚本改用宿主 Python
+        tool_python = Path(sys.executable) if is_cross else python_exe
+
         # 2. Python 依赖
-        step_download_python_deps(python_exe)
+        if is_cross:
+            pip_tag = "win_amd64" if os_arch in ("AMD64", "x86_64") else "win_arm64"
+            py_ver = ".".join(PYTHON_VERSION_TARGET.split(".")[:2])
+            step_download_python_deps(
+                tool_python, pip_platform_tag=pip_tag, python_version=py_ver
+            )
+        else:
+            step_download_python_deps(python_exe)
 
         # 3. MaaFramework
         step_download_maa_framework(os_arch)
@@ -611,14 +693,19 @@ def main():
         if not python_exe.exists():
             print(f"Python 未安装: {python_exe}，请先运行 build.py (不带 --skip-download)")
             sys.exit(1)
+        tool_python = Path(sys.executable) if is_cross else python_exe
 
     # 8. 安装 (MFAA 版本)
     if not skip_mfa:
-        step_install(python_exe, args.tag, platform_tag)
+        step_install(tool_python, args.tag, platform_tag)
 
     # 9. 安装 (MXU 版本)
     if not skip_mxu:
-        step_install_mxu(python_exe, args.tag)
+        step_install_mxu(
+            tool_python,
+            args.tag,
+            target_platform="win32" if is_cross else None,
+        )
 
     # 10. 整合 MFA
     if not skip_mfa:

--- a/build.py
+++ b/build.py
@@ -119,7 +119,8 @@ def get_platform(target_os="auto", target_arch="auto"):
             proc_id = os.environ.get("PROCESSOR_IDENTIFIER", "")
             if "ARMv8" in proc_id or "ARM64" in proc_id:
                 os_arch = "ARM64"
-        arch_map = {"AMD64": "AMD64", "x86_64": "AMD64", "ARM64": "ARM64", "aarch64": "ARM64"}
+        # 含 --target-arch 传入的小写 "arm64"（CLI choices 为小写）
+        arch_map = {"AMD64": "AMD64", "x86_64": "AMD64", "ARM64": "ARM64", "aarch64": "ARM64", "arm64": "ARM64"}
     elif os_type == "Darwin":
         arch_map = {"x86_64": "x86_64", "arm64": "arm64", "aarch64": "arm64"}
     elif os_type == "Linux":
@@ -638,9 +639,19 @@ def main():
         if r.returncode != 0:
             print("警告: git submodule 初始化失败，OCR 模型可能无法正确配置")
 
-    # 检测平台（target-os/target-arch 非 auto 时为交叉构建目标）
+    # 检测平台（target-os/target-arch 非 auto 时为交叉构建目标）。
+    # 交叉判定需同时比较 OS 与架构：同 OS 跨架构（如 Windows AMD64 宿主
+    # 指定 --target-arch arm64）时目标 python.exe 同样无法在宿主机执行
     os_type, os_arch, platform_tag = get_platform(args.target_os, args.target_arch)
-    is_cross = os_type != platform.system()
+
+    def _norm_arch(arch):
+        return {"amd64": "x86_64", "arm64": "arm64", "aarch64": "arm64"}.get(
+            str(arch).lower(), str(arch).lower()
+        )
+
+    is_cross = os_type != platform.system() or _norm_arch(os_arch) != _norm_arch(
+        platform.machine()
+    )
     if is_cross and os_type != "Windows":
         print(f"错误: 交叉构建仅支持 Windows 目标，当前目标: {os_type}")
         sys.exit(1)

--- a/build.py
+++ b/build.py
@@ -167,8 +167,12 @@ def _bootstrap_pip_offline(python_dir):
         shutil.rmtree(bootstrap_dir, ignore_errors=True)
 
 
-def step_setup_python(os_type, os_arch):
-    """步骤1: 安装嵌入式 Python + pip"""
+def step_setup_python(os_type, os_arch, is_cross=False):
+    """步骤1: 安装嵌入式 Python + pip
+
+    is_cross: 目标平台（OS 或架构）与宿主不一致时为 True，此时目标
+    python.exe 无法在宿主机执行，pip 走离线解压方式安装。
+    """
     print("\n" + "=" * 60)
     print("[1/12] 安装嵌入式 Python")
     print("=" * 60)
@@ -264,8 +268,9 @@ def step_setup_python(os_type, os_arch):
 
     # 安装 pip
     print("  安装 pip...")
-    if os_type == "Windows" and platform.system() != "Windows":
-        # 交叉构建：python.exe 无法在宿主机执行，走离线解压方式
+    if os_type == "Windows" and is_cross:
+        # 交叉构建（跨 OS 或同 OS 跨架构）：目标 python.exe 无法在
+        # 宿主机执行，走离线解压方式
         _bootstrap_pip_offline(PYTHON_DIR)
     else:
         get_pip_url = "https://bootstrap.pypa.io/get-pip.py"
@@ -666,7 +671,7 @@ def main():
 
     if not args.skip_download:
         # 1. 嵌入式 Python
-        python_exe = step_setup_python(os_type, os_arch)
+        python_exe = step_setup_python(os_type, os_arch, is_cross=is_cross)
 
         # 交叉构建时目标 python.exe 无法在宿主机执行，工具脚本改用宿主 Python
         tool_python = Path(sys.executable) if is_cross else python_exe

--- a/tools/ci/download_deps.py
+++ b/tools/ci/download_deps.py
@@ -10,9 +10,18 @@ import sys
 import subprocess
 import argparse
 import platform
+import zipfile
 from pathlib import Path
 
 sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+
+# packaging 随 pip 一起分发（pip._vendor），保证运行本脚本的任何 Python 环境都可用
+try:
+    from pip._vendor.packaging.requirements import Requirement
+    from pip._vendor.packaging.utils import canonicalize_name
+except ImportError:
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
 
 
 def get_platform_tag():
@@ -64,6 +73,135 @@ def get_platform_tag():
 
     print(f"使用平台标签: {platform_tag}")
     return platform_tag
+
+
+def _target_marker_environment(platform_tag, python_version):
+    """构造目标平台的 PEP 508 marker 评估环境。
+
+    pip download --platform 只影响 wheel 标签选择，Requires-Dist 中的环境
+    marker（如 loguru 的 colorama; sys_platform=='win32'）仍按宿主环境评估。
+    交叉下载时这会静默漏掉目标平台的条件依赖，导致离线安装失败，
+    必须用目标环境重新评估依赖闭包。
+    """
+    if python_version:
+        parts = python_version.split(".")
+        py_ver = ".".join(parts[:2])
+        py_full = python_version if len(parts) >= 3 else f"{py_ver}.0"
+    else:
+        py_ver = ".".join(str(v) for v in sys.version_info[:2])
+        py_full = platform.python_version()
+
+    if platform_tag.startswith("win"):
+        env = {
+            "sys_platform": "win32",
+            "platform_system": "Windows",
+            "os_name": "nt",
+            "platform_machine": "ARM64" if "arm64" in platform_tag else "AMD64",
+        }
+    elif platform_tag.startswith("macosx"):
+        env = {
+            "sys_platform": "darwin",
+            "platform_system": "Darwin",
+            "os_name": "posix",
+            "platform_machine": "arm64" if "arm64" in platform_tag else "x86_64",
+        }
+    else:
+        env = {
+            "sys_platform": "linux",
+            "platform_system": "Linux",
+            "os_name": "posix",
+            "platform_machine": "aarch64" if "aarch64" in platform_tag else "x86_64",
+        }
+
+    env.update(
+        {
+            "python_version": py_ver,
+            "python_full_version": py_full,
+            "implementation_name": "cpython",
+            "platform_python_implementation": "CPython",
+            "platform_release": "",
+            "platform_version": "",
+            # extra 置空：不评估 extras 引入的可选依赖
+            "extra": "",
+        }
+    )
+    return env
+
+
+def _find_missing_requirements(deps_path, env):
+    """扫描已下载 wheel 的 Requires-Dist，按目标环境评估 marker，
+    返回缺失的依赖 {canonical_name: 不含 marker 的 requirement 字符串}。
+
+    只做包名级校验：版本一致性由 pip download 的初始解析保证，
+    缺失项均为 marker 评估差异导致的整包遗漏。
+    """
+    have = set()
+    all_requires = []
+    for whl in sorted(Path(deps_path).glob("*.whl")):
+        have.add(canonicalize_name(whl.name.split("-")[0]))
+        try:
+            with zipfile.ZipFile(whl) as zf:
+                meta_name = next(
+                    n for n in zf.namelist() if n.endswith(".dist-info/METADATA")
+                )
+                meta = zf.read(meta_name).decode("utf-8", errors="replace")
+        except (StopIteration, zipfile.BadZipFile, OSError) as e:
+            print(f"警告: 无法读取 wheel 元数据 {whl.name}: {e}")
+            continue
+        for line in meta.split("\n"):
+            if line.startswith("Requires-Dist:"):
+                all_requires.append(line.split(":", 1)[1].strip())
+
+    missing = {}
+    for req_str in all_requires:
+        try:
+            req = Requirement(req_str)
+        except Exception:
+            continue
+        if req.marker is not None and not req.marker.evaluate(environment=env):
+            continue
+        name = canonicalize_name(req.name)
+        if name not in have and name not in missing:
+            missing[name] = f"{req.name}{req.specifier}"
+    return missing
+
+
+def _complete_dependency_closure(deps_path, platform_tag, python_version, max_rounds=5):
+    """迭代补齐目标平台的依赖闭包。新下载的 wheel 可能引入新的条件依赖，
+    循环校验直至闭包完整；超过 max_rounds 视为失败。
+    """
+    env = _target_marker_environment(platform_tag, python_version)
+    for round_index in range(max_rounds):
+        missing = _find_missing_requirements(deps_path, env)
+        if not missing:
+            if round_index > 0:
+                print("目标平台依赖闭包已补齐")
+            return True
+
+        print(f"闭包校验第 {round_index + 1} 轮，发现宿主 marker 评估漏掉的依赖: "
+              f"{', '.join(sorted(missing))}")
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "download",
+            *sorted(missing.values()),
+            "-d",
+            str(deps_path),
+            "--platform",
+            platform_tag,
+            "--only-binary=:all:",
+        ]
+        if python_version:
+            cmd += ["--python-version", python_version]
+        print(f"执行命令: {' '.join(cmd)}")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"补齐依赖闭包失败:\n{result.stdout}\n{result.stderr}")
+            return False
+
+    print(f"错误: 依赖闭包在 {max_rounds} 轮内未收敛")
+    return False
 
 
 def download_dependencies(deps_dir, platform_tag, python_version=None, allow_fallback=True):
@@ -122,6 +260,11 @@ def download_dependencies(deps_dir, platform_tag, python_version=None, allow_fal
         if result.stderr:
             print("警告信息:")
             print(result.stderr)
+
+        # 交叉下载模式：宿主评估 marker 会漏掉目标平台条件依赖，补齐闭包
+        if not allow_fallback:
+            if not _complete_dependency_closure(deps_path, platform_tag, python_version):
+                return False
 
         # 列出下载的文件
         whl_files = list(deps_path.glob("*.whl"))

--- a/tools/ci/download_deps.py
+++ b/tools/ci/download_deps.py
@@ -66,8 +66,14 @@ def get_platform_tag():
     return platform_tag
 
 
-def download_dependencies(deps_dir, platform_tag):
-    """下载依赖到指定目录"""
+def download_dependencies(deps_dir, platform_tag, python_version=None, allow_fallback=True):
+    """下载依赖到指定目录
+
+    python_version: 目标 Python 版本（如 "3.12"）。交叉构建时宿主 Python 版本
+    与打包目标不同，必须显式传入以获取正确 ABI 的 wheel。
+    allow_fallback: 平台特定下载失败时是否回退到不限平台的通用下载。
+    交叉构建时必须禁用——回退会静默混入宿主平台的二进制 wheel。
+    """
     # 创建deps目录
     deps_path = Path(deps_dir)
     deps_path.mkdir(parents=True, exist_ok=True)
@@ -106,6 +112,8 @@ def download_dependencies(deps_dir, platform_tag):
             platform_tag,
             "--only-binary=:all:",
         ]
+        if python_version:
+            cmd += ["--python-version", python_version]
 
         print(f"执行命令: {' '.join(cmd)}")
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
@@ -126,6 +134,13 @@ def download_dependencies(deps_dir, platform_tag):
 
     except subprocess.CalledProcessError as e:
         print(f"平台特定下载失败: {e}")
+        if not allow_fallback:
+            print("交叉构建模式：禁用通用回退下载（会混入宿主平台 wheel），直接失败")
+            if e.stdout:
+                print("stdout:", e.stdout)
+            if e.stderr:
+                print("stderr:", e.stderr)
+            return False
         if e.stderr and (
             "Could not find a version" in e.stderr
             or "No matching distribution" in e.stderr
@@ -185,15 +200,34 @@ def download_dependencies(deps_dir, platform_tag):
 def main():
     parser = argparse.ArgumentParser(description="下载Python依赖到deps目录")
     parser.add_argument("--deps-dir", default="deps", help="依赖下载目录 (默认: deps)")
+    parser.add_argument(
+        "--platform-tag",
+        default=None,
+        help="pip 平台标签（如 win_amd64）。指定后跳过宿主平台自动探测，用于交叉构建",
+    )
+    parser.add_argument(
+        "--python-version",
+        default=None,
+        help='目标 Python 版本（如 "3.12"）。交叉构建时必须与打包的 Python 一致',
+    )
 
     args = parser.parse_args()
 
     try:
-        # 自动检测平台
-        platform_tag = get_platform_tag()
+        if args.platform_tag:
+            platform_tag = args.platform_tag
+            print(f"使用指定平台标签: {platform_tag}")
+        else:
+            # 自动检测平台
+            platform_tag = get_platform_tag()
 
         # 下载依赖
-        success = download_dependencies(args.deps_dir, platform_tag)
+        success = download_dependencies(
+            args.deps_dir,
+            platform_tag,
+            python_version=args.python_version,
+            allow_fallback=args.platform_tag is None,
+        )
 
         if success:
             print("✅ 依赖下载成功")

--- a/tools/ci/download_deps.py
+++ b/tools/ci/download_deps.py
@@ -178,7 +178,10 @@ def _find_missing_requirements(deps_path, env):
             continue
         name = canonicalize_name(req.name)
         if name not in have and name not in missing:
-            missing[name] = f"{req.name}{req.specifier}"
+            # 保留 extras（如 pkg[extra]）：补齐下载时让 pip 一并解析
+            # extras 引入的附加依赖，否则闭包仍然不完整
+            extras = f"[{','.join(sorted(req.extras))}]" if req.extras else ""
+            missing[name] = f"{req.name}{extras}{req.specifier}"
     return missing
 
 

--- a/tools/ci/download_deps.py
+++ b/tools/ci/download_deps.py
@@ -5,6 +5,7 @@
 自动检测当前平台并下载对应架构的wheel文件
 """
 
+import email
 import os
 import sys
 import subprocess
@@ -22,6 +23,14 @@ try:
 except ImportError:
     from packaging.requirements import Requirement
     from packaging.utils import canonicalize_name
+
+try:
+    from pip._vendor.packaging.markers import default_environment as _default_marker_environment
+except ImportError:
+    try:
+        from packaging.markers import default_environment as _default_marker_environment
+    except ImportError:
+        _default_marker_environment = None
 
 
 def get_platform_tag():
@@ -113,11 +122,16 @@ def _target_marker_environment(platform_tag, python_version):
             "platform_machine": "aarch64" if "aarch64" in platform_tag else "x86_64",
         }
 
-    env.update(
+    # 以 default_environment() 补齐 PEP 508 全部标准键（如 implementation_version），
+    # 避免 marker 使用未覆盖的变量时评估出错；目标平台相关字段随后全部覆盖
+    base_env = dict(_default_marker_environment()) if _default_marker_environment else {}
+    base_env.update(env)
+    base_env.update(
         {
             "python_version": py_ver,
             "python_full_version": py_full,
             "implementation_name": "cpython",
+            "implementation_version": py_full,
             "platform_python_implementation": "CPython",
             "platform_release": "",
             "platform_version": "",
@@ -125,7 +139,7 @@ def _target_marker_environment(platform_tag, python_version):
             "extra": "",
         }
     )
-    return env
+    return base_env
 
 
 def _find_missing_requirements(deps_path, env):
@@ -148,9 +162,11 @@ def _find_missing_requirements(deps_path, env):
         except (StopIteration, zipfile.BadZipFile, OSError) as e:
             print(f"警告: 无法读取 wheel 元数据 {whl.name}: {e}")
             continue
-        for line in meta.split("\n"):
-            if line.startswith("Requires-Dist:"):
-                all_requires.append(line.split(":", 1)[1].strip())
+        # METADATA 为 RFC 822 风格头部，Requires-Dist 允许折叠续行（PEP 566），
+        # 用 email 解析器正确合并续行，避免按行解析丢失折叠部分
+        msg = email.message_from_string(meta)
+        for req_line in msg.get_all("Requires-Dist") or []:
+            all_requires.append(" ".join(str(req_line).split()))
 
     missing = {}
     for req_str in all_requires:

--- a/tools/ci/install_mxu.py
+++ b/tools/ci/install_mxu.py
@@ -22,6 +22,8 @@ def load_json_with_comments(path):
 working_dir = Path(__file__).parent.parent.parent
 install_path = working_dir / Path("install-mxu")
 version = len(sys.argv) > 1 and sys.argv[1] or "v0.0.1"
+# argv[2]: 目标平台（win32/darwin/linux），交叉构建时由 build.py 传入；缺省为宿主平台
+target_platform = sys.argv[2] if len(sys.argv) > 2 else sys.platform
 
 
 def install_deps():
@@ -92,11 +94,11 @@ def install_agent():
 
     interface = load_json_with_comments(install_path / "interface.json")
 
-    if sys.platform.startswith("win"):
+    if target_platform.startswith("win"):
         interface["agent"]["child_exec"] = r"./python/python.exe"
-    elif sys.platform.startswith("darwin"):
+    elif target_platform.startswith("darwin"):
         interface["agent"]["child_exec"] = r"./python/bin/python3"
-    elif sys.platform.startswith("linux"):
+    elif target_platform.startswith("linux"):
         interface["agent"]["child_exec"] = r"python3"
 
     interface["agent"]["child_args"] = ["-u", r"./agent/main.py"]


### PR DESCRIPTION
## 变更摘要

- `build.py` 新增 `--target-os windows` / `--target-arch {x86_64,arm64}`：在 Linux/macOS 宿主机上下载 Windows 目标产物（python.org 嵌入式 Python、MaaFramework win 包、MXU win 包）并组装完整 Windows 发行包，产出与 Windows 本机构建一致的 `MaaNTE-win-<arch>-<tag>-MXU.zip`。
- 交叉构建时工具脚本自动改用宿主 Python 执行（目标 python.exe 无法在宿主机运行），pip 依赖按 `--platform win_amd64 --only-binary=:all:` 下载目标平台 wheel。
- `tools/ci/download_deps.py` 新增目标平台依赖闭包校验：宿主机 pip 按宿主环境评估 environment marker 会漏掉 Windows-only 传递依赖（实测漏 `colorama`、`win32-setctime`），下载后逐 wheel 解析 METADATA 的 Requires-Dist 迭代补齐，直至闭包收敛。
- 仅新增路径：Windows 本机构建流程与产物不受任何影响（`--target-os auto` 默认宿主平台，原有行为不变）。

## 验证记录

- Linux 宿主机（RHEL 9）交叉构建 `--mode=mxu --target-os windows`：完整产出发行包，45 个 win_amd64 wheel 闭包收敛（含 2 个宿主 marker 漏掉后被补齐的依赖）。
- 产出包在 Windows 11 实机解压运行：MaaNTE.exe 启动、agent 依赖从本地 deps 安装成功、控制器连接与任务执行正常（与 GFN 支持 PR 的实测为同一批产出包，多个迭代版本反复验证）。
- 重复构建幂等：已存在的 deps/、MXU/、嵌入式 Python 自动跳过下载。

Related: N/A（无对应 issue，如需要可补开）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在保持现有原生 Windows 构建不变的前提下，使得可以在 Linux/macOS 主机上进行 Windows 发布包的跨平台组装。

New Features:
- 为 `build.py` 添加选项，以便指定目标操作系统/架构，使 Linux/macOS 主机能够组装与原生构建输出一致的 Windows 发布包。

Bug Fixes:
- 通过迭代验证并补全依赖闭包，确保跨构建的 Windows 包所使用的依赖轮子包含所有仅在 Windows 上生效的条件依赖。
- 在指定目标平台时禁用通用的 `pip download` 回退逻辑，防止主机平台的轮子被混入跨构建产物中。

Enhancements:
- 让打包格式的选择依赖目标平台的标签，这样即使在非 Windows 主机上构建，Windows 构建产物也始终使用 zip 格式。
- 允许 `install_mxu` 工具接收显式的目标平台参数，以确保在跨构建场景下，`interface.json` 中的 `child_exec` 路径正确。

Build:
- 为 `tools/ci/download_deps.py` 添加跨平台依赖下载选项和具备标记感知能力的闭包验证，包括对显式平台标签和目标 Python 版本的支持。
- 为嵌入式 Python 在跨构建场景下引入离线 `pip` 引导机制，以便在目标 `python.exe` 无法在主机上执行时仍能完成初始化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable cross-assembly of Windows release packages from Linux/macOS hosts while keeping existing native Windows builds unchanged.

New Features:
- Add build.py options to target a specific OS/architecture so Linux/macOS hosts can assemble Windows release packages matching native outputs.

Bug Fixes:
- Ensure dependency wheels for cross-built Windows packages include all Windows-only conditional requirements by iteratively validating and completing the dependency closure.
- Prevent host-platform wheels from being mixed into cross-built artifacts by disabling generic pip download fallback when a target platform is specified.

Enhancements:
- Make packaging format selection depend on target platform tags so Windows artifacts are always zipped even when built on non-Windows hosts.
- Allow install_mxu tooling to receive an explicit target platform so interface.json child_exec paths are correct in cross-builds.

Build:
- Add cross-platform dependency download options and marker-aware closure validation to tools/ci/download_deps.py, including support for explicit platform tags and target Python versions.
- Introduce an offline pip bootstrap mechanism for embedded Python in cross-builds where the target python.exe cannot be executed on the host.

</details>