### PR TITLE
fix: 修复做咖啡选项

### DIFF
--- a/assets/resource/locales/interface/en_us.json
+++ b/assets/resource/locales/interface/en_us.json
@@ -56,6 +56,7 @@
     "task_make_coffee_lite_label": "Auto Make Coffee (Lite)",
     "task_make_coffee_lite_desc": "Start the task on the stage selection page. No special character is required",
     "task_make_coffee_option_loop_time": "Make Count",
+    "task_make_coffee_lite_option": "Make Settings",
     "task_make_coffee_lite_option_loop_time": "Make Count",
     "task_make_coffee_lite_option_timeout": "Making Timeout (seconds)",
     "task_rhythm_label": "Super Sound",

--- a/assets/resource/locales/interface/ja_jp.json
+++ b/assets/resource/locales/interface/ja_jp.json
@@ -76,6 +76,7 @@
     "task_make_coffee_lite_label": "自動でコーヒーを作ります（簡易版）",
     "task_make_coffee_lite_desc": "ステージ選択画面でタスクを開始します。特別なキャラクターは不要です",
     "task_make_coffee_option_loop_time": "製作回数",
+    "task_make_coffee_lite_option": "コーヒー作成設定",
     "task_make_coffee_lite_option_loop_time": "製作回数",
     "task_make_coffee_lite_option_timeout": "製作タイムアウト時間(秒)",
     "task_rhythm_label": "ハイパーサウンド",

--- a/assets/resource/locales/interface/ko_kr.json
+++ b/assets/resource/locales/interface/ko_kr.json
@@ -56,6 +56,7 @@
     "task_make_coffee_lite_label": "자동 커피 제조(라이트 버전)",
     "task_make_coffee_lite_desc": "스테이지 선택 화면에서 작업을 시작합니다. 특별한 캐릭터는 필요하지 않습니다",
     "task_make_coffee_option_loop_time": "제조 횟수",
+    "task_make_coffee_lite_option": "커피 만들기 설정",
     "task_make_coffee_lite_option_loop_time": "제조 횟수",
     "task_make_coffee_lite_option_timeout": "제조 타임아웃 시간(초)",
     "task_rhythm_label": "하이퍼 사운드",

--- a/assets/resource/locales/interface/zh_cn.json
+++ b/assets/resource/locales/interface/zh_cn.json
@@ -56,6 +56,7 @@
     "task_make_coffee_lite_label": "自动做咖啡(平民版)",
     "task_make_coffee_lite_desc": "在选择关卡页面开始任务，无需特殊角色",
     "task_make_coffee_option_loop_time": "制作次数",
+    "task_make_coffee_lite_option": "做咖啡设置",
     "task_make_coffee_lite_option_loop_time": "制作次数",
     "task_make_coffee_lite_option_timeout": "制作超时退出时间(秒)",
     "task_rhythm_label": "超强音",

--- a/assets/resource/locales/interface/zh_tw.json
+++ b/assets/resource/locales/interface/zh_tw.json
@@ -76,6 +76,7 @@
     "task_make_coffee_lite_label": "自動做咖啡（平民版）",
     "task_make_coffee_lite_desc": "在選擇關卡頁面開始任務，無需特殊角色",
     "task_make_coffee_option_loop_time": "製作次數",
+    "task_make_coffee_lite_option": "做咖啡設定",
     "task_make_coffee_lite_option_loop_time": "製作次數",
     "task_make_coffee_lite_option_timeout": "製作超時退出時間(秒)",
     "task_rhythm_label": "超強音",

--- a/assets/resource/tasks/MakeCoffeeLite.json
+++ b/assets/resource/tasks/MakeCoffeeLite.json
@@ -6,8 +6,7 @@
             "desc": "$task_make_coffee_lite_desc",
             "entry": "AutoMakeCoffeeLiteEntrance",
             "option": [
-                "MakeCoffeeLoopTimeLite",
-                "MakeCoffeeTimeoutLite"
+                "MakeCoffeeLoopTimeAndTimeout"
             ],
             "controller": [
                 "Win32-Front"
@@ -18,38 +17,29 @@
         }
     ],
     "option": {
-        "MakeCoffeeLoopTimeLite": {
-            "label": "$task_make_coffee_lite_option_loop_time",
+        "MakeCoffeeLoopTimeAndTimeout": {
             "type": "input",
+            "label": "$task_make_coffee_lite_option",
             "inputs": [
                 {
                     "name": "LoopTime",
                     "default": "10",
+                    "label": "$task_make_coffee_lite_option_loop_time",
                     "pipeline_type": "int"
-                }
-            ],
-            "pipeline_override": {
-                "MakeCoffeeLiteRun": {
-                    "custom_action_param": {
-                        "count": "{LoopTime}"
-                    }
-                }
-            }
-        },
-        "MakeCoffeeTimeoutLite": {
-            "label": "$task_make_coffee_lite_option_timeout",
-            "type": "input",
-            "inputs": [
+                },
                 {
                     "name": "Timeout",
                     "default": "5",
+                    "label": "$task_make_coffee_lite_option_timeout",
                     "pipeline_type": "int"
+                    
                 }
             ],
             "pipeline_override": {
                 "MakeCoffeeLiteRun": {
                     "custom_action_param": {
-                        "timeout": "{Timeout}"
+                        "timeout": "{Timeout}",
+                        "count": "{LoopTime}"
                     }
                 }
             }


### PR DESCRIPTION
## 关联 Issue
#388 
代码问题导致选项配置被覆盖

## 变更摘要
1. 更改选项配置
2. 增加翻译


- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## Summary by Sourcery

调整 MakeCoffeeLite 任务选项配置，防止煮咖啡选项被覆盖，并更新相关的界面翻译。

Bug 修复：
- 修复配置问题，解决导致 MakeCoffeeLite 煮咖啡选项被覆盖的错误。

增强改进：
- 优化 MakeCoffeeLite 任务选项定义，使其在不同语言环境下表现更加一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust MakeCoffeeLite task option configuration to prevent coffee-making options from being overwritten and update related UI translations.

Bug Fixes:
- Fix configuration issue causing MakeCoffeeLite coffee-making options to be overridden.

Enhancements:
- Refine MakeCoffeeLite task option definitions for more consistent behavior across locales.

</details>