### PR TITLE
fix(teleport_to_point):修复click_teleport_button只点击固定ROI的问题

### DIFF
--- a/agent/custom/action/MapTeleport/teleport_to_point.py
+++ b/agent/custom/action/MapTeleport/teleport_to_point.py
@@ -220,9 +220,9 @@ def _click_rect_action(context: Context, rect: list[int]) -> bool:
 def _swipe_up_in_roi(context: Context, roi: list[int], *, duration: int) -> bool:
     x, y, w, h = roi
     start_x = int(x + w / 2)
-    start_y = int(y + h * 0.82)
+    start_y = int(y + h)  # 从 ROI 最底下
     end_x = start_x
-    end_y = int(y + h * 0.18)
+    end_y = int(y)  # 拖到 ROI 最顶上
     try:
         context.tasker.controller.post_swipe(
             start_x,
@@ -569,7 +569,7 @@ def _drag_list_upward(
     if drag_start is None:
         return False
 
-    roi = [drag_start[0] - 1, drag_start[1] - 20, 2, 20]
+    roi = [drag_start[0] - 1, drag_start[1] - 17, 2, 20]
     if not _swipe_up_in_roi(context, roi, duration=200):
         return False
 
@@ -612,7 +612,7 @@ def _drag_zoom_control(
     *,
     template_threshold: float = DEFAULT_TEMPLATE_THRESHOLD,
 ) -> bool:
-    """拖动缩放调节按钮。识别按钮后向下拖拽 300px 缩小地图视图。"""
+    """拖动缩放调节按钮。识别按钮后向上拖拽放大地图视图。"""
     frame = _wait_screen_still(context, max_wait=3.0)
     template = _load_template(ZOOM_CONTROL_BTN_TEMPLATE)
 
@@ -630,6 +630,7 @@ def _drag_zoom_control(
     cx = x + w // 2
     cy = y + h // 2
 
+    # roi 底部正好落在按钮中心 (cx, cy)，从按钮拖到上方 300px
     end_y = cy - 300
     roi = [cx - 1, end_y, 2, 300]
     if not _swipe_up_in_roi(context, roi, duration=300):
@@ -778,7 +779,8 @@ def _click_teleport_button(
         if detail is None:
             return False
 
-    return _click_rect_action(context, TELEPORT_BUTTON_ROI)
+    rect = _detail_box(detail) or TELEPORT_BUTTON_ROI
+    return _click_rect_action(context, rect)
 
 
 def _wait_teleport_loading(context: Context) -> bool:


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

测试时发现click_teleport_button乱点，问题是click_teleport_button原逻辑只识别存在“传送”+点击固定区域ROI，导致当ROI区域内存在其他按钮（列如维特海默塔同时存在“传送”和“异象委托”）的时候乱点

## 变更摘要

1.click_teleport_button点击时使用OCR识别的ROI
2.修改部分注释

## 验证

- [ ] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## Summary by Sourcery

改进地图传送交互，使用 OCR 获取的区域并调整滑动行为，以实现更精确的控制。

错误修复：
- 修复传送按钮点击逻辑，改为使用检测到的详情框区域而不是固定的 ROI，避免在区域内存在多个按钮时发生误点。

增强功能：
- 调整 ROI 内的垂直滑动计算，从底部向顶部拖动，以实现更可靠的向上滚动。
- 更新拖拽列表的 ROI 位置，使其与拖拽起始点更好对齐。
- 更改缩放控制行为，通过向上拖动来放大，并记录围绕缩放按钮的 ROI 对齐方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve map teleport interactions to use OCR-derived regions and adjust swipe behavior for more accurate control.

Bug Fixes:
- Fix teleport button clicking to use the detected detail box region instead of a fixed ROI, avoiding misclicks when multiple buttons are present in the area.

Enhancements:
- Adjust vertical swipe calculations within ROIs to drag from the bottom to the top for more reliable upward scrolling.
- Update drag list ROI positioning for better alignment with the drag start point.
- Change zoom control behavior to drag upward to zoom in and document the ROI alignment around the zoom button.

</details>