### PR TITLE
fix(BidKing): 修正开始匹配等三个节点的 roi 坐标

### DIFF
--- a/assets/resource/base/pipeline/BidKing/BidKing.json
+++ b/assets/resource/base/pipeline/BidKing/BidKing.json
@@ -38,10 +38,10 @@
             "param": {
                 "template": "BidKing/start.png",
                 "roi": [
-                    973,
-                    630,
-                    93,
-                    34
+                    953,
+                    616,
+                    133,
+                    74
                 ],
                 "threshold": 0.7
             }
@@ -211,10 +211,10 @@
             "param": {
                 "template": "BidKing/skip.png",
                 "roi": [
-                    925,
-                    658,
-                    84,
-                    31
+                    905,
+                    631,
+                    124,
+                    71
                 ],
                 "threshold": 0.7
             }
@@ -237,10 +237,10 @@
             "param": {
                 "template": "BidKing/exit.png",
                 "roi": [
-                    1106,
-                    661,
-                    70,
-                    27
+                    1086,
+                    637,
+                    110,
+                    71
                 ],
                 "threshold": 0.7
             }


### PR DESCRIPTION
## 关联 Issue

Fixes #401

## 变更摘要

- `BidKingStart`、`BidKingSkip`、`BidKingExit` 三个节点的 `roi` 指向的位置与按钮实际位置不符，且 `roi` 尺寸与模板等大（搜索窗口 1×1），模板只能落在 `roi` 原点，因此永远无法命中
- 其中 `BidKingStart` 失配即 #401 的直接原因：任务在 `BidKingRound → BidKingStart` 之间无限空转，既不报错也不停止，表现为"点了开始没反应"
- 三个节点的 `roi` 修正为同时覆盖实测位置与原坐标，余裕 40×40（`BidKingExit` 70×49）
- 其余 5 个节点实测位置与原 `roi` 原点完全一致，未改动
- 仅改动 `roi` 数值，未改动节点结构、`next`、`threshold` 或模板图片

## 验证

测试入口：`BidKing`（自动拍卖之王），控制器 `Win32-Front`，游戏 1280×720 窗口化，循环次数 1

- [x] 复现：修改前 `BidKingStart` 得分恒为 0.218206（阈值 0.7），日志中 `box` 恒为 `[973,630,93,34]`，即搜索窗口与模板等大，只能落在 `roi` 原点
- [x] 定位：对整帧做 `TM_CCOEFF_NORMED` 全图搜索，`start.png` 以 **1.0000** 命中 client 坐标 **(973, 636)**；再用 `start.png` 与 `balance.png` 分别回推 client 原点，两者结果一致，确认截图为 1:1 无缩放
- [x] 交叉验证：对 #401 楼主在该 issue 上传的截图做同样测量，`start.png` 同样以 1.0000 命中 (973, 636)，与本机一致，确认与环境无关
- [x] 修改后完整跑通一轮：22:40:49 启动 → 22:42:59 结束，5 次出价，最终 `Tasker.Task.Succeeded`
- [x] 全流程节点均按预期命中，且命中位置均落在各自 `roi` 内：
      `Start`(1.0000) → `Confirm`(1.0000) → `Balance`(0.9951) → [`Bid`(1.0000) → `SelectOne`(0.9998) → `ConfirmBid`(1.0000)] ×5 → `Skip`(0.9879) → `Exit`(0.9829) → `TaskExit`(StopTask)
- [x] 三个修改节点的实际位置在两次独立运行中完全一致
- [x] 边界检查：三个新 `roi` 均在 1280×720 内，且不小于对应模板尺寸
- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

修改前 `debug/maafw.log` 节选（`box` 即实际搜索窗口，与模板等大）：

```
[TemplateMatcher.cpp][L45][MaaNS::VisionNS::TemplateMatcher::analyze] BidKingStart
[all_results_=[{"box":[973,630,93,34],"score":0.218206}]]
[filtered_results_=[]] [best_result_=null]
[param_.template_=["BidKing/start.png"]] [param_.thresholds=[0.700000]] [param_.method=5]
```

修改后完整一轮中，各节点实际命中位置与原 `roi` 的对比（client 坐标，1280×720 基准）：

| 节点 | 实际命中 box | 原 roi | 模板尺寸 | 原 roi 余裕 | 偏差 | 原版可命中 |
|---|---|---|---|---|---|---|
| `BidKingStart` | `[973, 636, 93, 34]` | `[973, 630, 93, 34]` | 93×34 | 0×0 | +0, +6 | 否 |
| `BidKingSkip` | `[925, 651, 84, 31]` | `[925, 658, 84, 31]` | 84×31 | 0×0 | +0, −7 | 否 |
| `BidKingExit` | `[1114, 657, 40, 22]` | `[1106, 661, 70, 27]` | 40×22 | 30×5 | +8, −4 | 否 |
| `BidKingConfirm` | `[738, 455, 71, 39]` | `[738, 455, 71, 39]` | 71×39 | 0×0 | 0, 0 | 是 |
| `BidKingBalance` | `[952, 26, 83, 34]` | `[952, 26, 83, 34]` | 83×34 | 0×0 | 0, 0 | 是 |
| `BidKingBid` | `[1129, 654, 62, 35]` | `[1129, 654, 62, 35]` | 62×35 | 0×0 | 0, 0 | 是 |
| `BidKingSelectOne` | `[271, 355, 71, 57]` | `[271, 355, 71, 57]` | 71×57 | 0×0 | 0, 0 | 是 |
| `BidKingConfirmBid` | `[835, 624, 90, 31]` | `[835, 624, 90, 31]` | 90×31 | 0×0 | 0, 0 | 是 |

即使只修 `BidKingStart`，流程也会在 `BidKingSkip` 处卡死，因此三个节点需一并修正。

修改后的 `roi` 同时覆盖实测位置与原坐标：

| 节点 | 新 roi | 模板尺寸 | 余裕 |
|---|---|---|---|
| `BidKingStart` | `[953, 616, 133, 74]` | 93×34 | 40×40 |
| `BidKingSkip` | `[905, 631, 124, 71]` | 84×31 | 40×40 |
| `BidKingExit` | `[1086, 637, 110, 71]` | 40×22 | 70×49 |

模板路径：`assets/resource/base/image/BidKing/{start,skip,exit}.png`（未改动）

界面跳转关系（未改动，列出以便对照 `roi`）：

```
拍卖大厅（「开始匹配」可见）
  → 点击「开始匹配」 → 确认弹窗（「确认」）
  → 拍卖进行中（右上角余额标识出现）
  → 循环：「出价」 → 选择数量「1」 → 「确认出价」 → 回到拍卖中
  → 出现「跳过」即本轮结束 → 「退出」 → 回到拍卖大厅
```

## Summary by Sourcery

调整 BidKing 自动化的 ROI 配置，使模板匹配能正确检测到 Start、Skip 和 Exit 按钮，从而让 BidKing 流程在不卡住的情况下顺利完成。

Bug 修复：
- 修复 BidKingStart、BidKingSkip 和 BidKingExit 的 ROI 位置和尺寸错误问题，这些错误会导致其模板永远无法匹配，从而使 BidKing 任务在流程中挂起。
- 确保所有 BidKing 的 ROI 都保持在 1280×720 客户端边界内，并且足够大以包含相应的按钮模板。

功能增强：
- 加宽 BidKing Start、Skip 和 Exit 按钮的 ROI，使其既涵盖原始坐标又覆盖在屏幕上测量到的位置，并增加一定边距以容忍轻微的布局变化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust BidKing automation ROI configurations so template matching correctly detects the Start, Skip, and Exit buttons and the BidKing flow can complete without stalling.

Bug Fixes:
- Fix incorrect ROI positions and sizes for BidKingStart, BidKingSkip, and BidKingExit that prevented their templates from ever matching, causing the BidKing task to hang in the flow.
- Ensure all BidKing ROIs stay within the 1280×720 client bounds and are large enough to encompass the corresponding button templates.

Enhancements:
- Widen ROIs for the BidKing Start, Skip, and Exit buttons to include both the original coordinates and the measured on-screen positions, adding margin for minor layout variation.

</details>