### PR TITLE
fix(interface): 修复LICENCE链接指向错误问题并添加更多联系信息

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -3,7 +3,7 @@
     "name": "MaaNTE",
     "description": "$description",
     "contact": "$contact",
-    "license": "[GNU Affero General Public License v3.0 (AGPL-3.0)](https://github.com/MaaEnd/MaaEnd/blob/v2/LICENSE)",
+    "license": "[GNU Affero General Public License v3.0 (AGPL-3.0)](https://github.com/1bananachicken/MaaNTE/blob/dev/LICENSE)",
     "welcome": "$welcome.file",
     "github": "https://github.com/1bananachicken/MaaNTE",
     "icon": "logo.ico",

--- a/assets/resource/locales/interface/en_us.json
+++ b/assets/resource/locales/interface/en_us.json
@@ -1,7 +1,7 @@
 {
     "description": "NTE Assistant, powered by MaaFramework!",
     "scene_check_osd_failed_focus": "<span style=\"color: red; font-weight: bold;\">Screen obstructed, please disable FPS overlay</span>",
-    "contact": "QQ Group: 1103323319",
+    "contact": "GitHub Repo: [1bananachicken/MaaNTE](https://github.com/1bananachicken/MaaNTE/)<br>Official Website: https://maante.org/<br>QQ Group: [Get info from official site](https://maante.org/zh_cn/qq-group/) or 1103323319<br>Discord: https://discord.com/invite/e6mPMRYQpR",
     "welcome.file": "resource/locales/interface/WELCOME/WELCOME_en_us.md",
     "controller_default_label": "Win32 - Default",
     "controller_front_label": "Win32 - Front",

--- a/assets/resource/locales/interface/ja_jp.json
+++ b/assets/resource/locales/interface/ja_jp.json
@@ -1,7 +1,7 @@
 {
     "description": "異環アシスタント、MaaFrameworkにより駆動！",
     "scene_check_osd_failed_focus": "<span style=\"color: red; font-weight: bold;\">画面が遮られています。フレームレート表示をオフにしてください</span>",
-    "contact": "QQグループ: 1103323319",
+    "contact": "GitHub リポジトリ: [1bananachicken/MaaNTE](https://github.com/1bananachicken/MaaNTE/)<br>公式サイト: https://maante.org/<br>QQグループ: [公式サイトから取得](https://maante.org/zh_cn/qq-group/) または 1103323319<br>Discord: https://discord.com/invite/e6mPMRYQpR",
     "welcome.file": "resource/locales/interface/WELCOME/WELCOME_ja_jp.md",
     "controller_default_label": "デスクトップ - デフォルト",
     "controller_front_label": "デスクトップ - フォアグラウンド",

--- a/assets/resource/locales/interface/ko_kr.json
+++ b/assets/resource/locales/interface/ko_kr.json
@@ -1,7 +1,7 @@
 {
     "description": "NTE 어시스턴트, MaaFramework 기반 구동!",
     "scene_check_osd_failed_focus": "<span style=\"color: red; font-weight: bold;\">화면이 가려져 있습니다. 프레임 레이트 표시를 비활성화하세요</span>",
-    "contact": "QQ 그룹: 1103323319",
+    "contact": "GitHub 저장소: [1bananachicken/MaaNTE](https://github.com/1bananachicken/MaaNTE/)<br>공식 웹사이트: https://maante.org/<br>QQ 그룹: [공식 사이트에서 확인](https://maante.org/zh_cn/qq-group/) 또는 1103323319<br>Discord: https://discord.com/invite/e6mPMRYQpR",
     "welcome.file": "resource/locales/interface/WELCOME/WELCOME_ko_kr.md",
     "controller_default_label": "데스크톱 - 기본",
     "controller_front_label": "데스크톱 - 포그라운드",

--- a/assets/resource/locales/interface/zh_cn.json
+++ b/assets/resource/locales/interface/zh_cn.json
@@ -1,7 +1,7 @@
 {
     "description": "异环小助手，由MAAFramework强力驱动！",
     "scene_check_osd_failed_focus": "<span style=\"color: red; font-weight: bold;\">屏幕存在遮挡，请尝试关闭帧率显示</span>",
-    "contact": "QQ群: 1103323319",
+    "contact": "GitHub 仓库: [1bananachicken/MaaNTE](https://github.com/1bananachicken/MaaNTE/)<br>官方网站: https://maante.org/<br>QQ群: [点击前往官网获取](https://maante.org/zh_cn/qq-group/)或1103323319",
     "welcome.file": "resource/locales/interface/WELCOME/WELCOME_zh_cn.md",
     "controller_default_label": "桌面端-默认",
     "controller_front_label": "桌面端-前台",

--- a/assets/resource/locales/interface/zh_tw.json
+++ b/assets/resource/locales/interface/zh_tw.json
@@ -1,7 +1,7 @@
 {
     "description": "異環小助手，由MaaFramework強力驅動！",
     "scene_check_osd_failed_focus": "<span style=\"color: red; font-weight: bold;\">螢幕存在遮擋，請嘗試關閉幀率顯示</span>",
-    "contact": "QQ群: 1103323319",
+    "contact": "GitHub 倉庫: [1bananachicken/MaaNTE](https://github.com/1bananachicken/MaaNTE/)<br>官方網站: https://maante.org/<br>QQ群: [點擊前往官網獲取](https://maante.org/zh_cn/qq-group/)或1103323319<br>Discord: https://discord.com/invite/e6mPMRYQpR",
     "welcome.file": "resource/locales/interface/WELCOME/WELCOME_zh_tw.md",
     "controller_default_label": "桌面端-默認",
     "controller_front_label": "桌面端-前台",


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)。

## 关联 Issue

close #419

## 变更摘要

- 修复LICENCE链接错误地指向 MaaEnd 的问题
- 为 contact 添加 repo 、网站等

## 验证

本地编译信息显示正常

- [x] 我已阅读并遵守 [PR 规范](docs/zh_cn/develop/pull-request-guidelines.md)

## 截图 / 日志 / 说明

<!-- 涉及识别、点击、界面跳转或 Bug 修复时，请提供截图、ROI、模板路径或 maa.log 关键片段。 -->

## Sourcery 摘要

修正界面许可证链接，并在所有受支持的语言环境中补充联系信息。

新功能：
- 在界面元数据中添加代码仓库和网站联系信息。

错误修复：
- 修正许可证链接，使其不再指向 MaaEnd。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct the interface licence link and expand contact information across all supported locales.

New Features:
- Add repository and website contact information to the interface metadata.

Bug Fixes:
- Correct the licence link so it no longer points to MaaEnd.

</details>