### PR TITLE
fix(FishNew):修复了钓鱼中购买鱼饵点击识别成下拉导致买错鱼饵的问题

### DIFF
--- a/assets/resource/base/pipeline/Fish/FishNew.json
+++ b/assets/resource/base/pipeline/Fish/FishNew.json
@@ -400,7 +400,8 @@
             }
         },
         "next": [
-            "FishNewStoreChooseGeneralBait"
+            "FishNewStoreChooseGeneralBait",
+            "FishNewStoreScrollUpAfterMiss"
             // "[JumpBack]FishNewStoreScrollMouse"
         ],
         "on_error": [
@@ -459,8 +460,126 @@
         "order_by": "Score", // 默认似乎不是按置信度排的，需要显式声明
         "action": "Click",
         "next": [
+            "FishNewStoreManualScrollWait",
+            "FishNewStoreScrollUp"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
+        ]
+    },
+    // 已完成点击被误识别为滑动的回归测试，正式流程不主动下滚。
+    // 如需再次测试，可将上方 next 临时改为 FishNewStoreScrollDownTest，
+    // 并恢复以下测试节点；测试完成后保持正式流程直接进入 Verify。
+    // "FishNewStoreScrollDownTest": {
+    //     "desc": "测试：点击万能鱼饵后主动向下滚动，再执行点击复核",
+    //     "recognition": {
+    //         "type": "And",
+    //         "param": {
+    //             "all_of": [
+    //                 "FishNewOnStore"
+    //             ]
+    //         }
+    //     },
+    //     "action": "Scroll",
+    //     "target": [
+    //         220,
+    //         350
+    //     ],
+    //     "dy": -1200,
+    //     "next": [
+    //         "FishNewStoreChooseGeneralBaitVerify",
+    //         "FishNewStoreScrollUp"
+    //     ],
+    //     "on_error": [
+    //         "[Anchor]FishNewErrorRestart"
+    //     ]
+    // },
+    "FishNewStoreManualScrollWait": { // 拉长以手动进行错误向下滚动后的上滚代码测试，缩短时间保留在正常流程中防止破坏结构，因为该节点完成后会继续检查，没找到就继续往上
+        "desc": "点击鱼饵后短暂等待，再执行点击复核",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "FishNewOnStore"
+                ]
+            }
+        },
+        "action": "DoNothing",
+        "post_delay": 500,
+        "next": [
+            "FishNewStoreChooseGeneralBaitVerify",
+            "FishNewStoreScrollUp"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
+        ]
+    },
+    "FishNewStoreChooseGeneralBaitVerify": {
+        "desc": "点击万能鱼饵后再次识别，确认点击没有被识别为滑动",
+        "recognition": "TemplateMatch",
+        "roi": [
+            26,
+            81,
+            418,
+            585
+        ],
+        "template": [
+            "Fish/FishStoreGeneralBait.png"
+        ],
+        "green_mask": true,
+        "order_by": "Score",
+        "action": "DoNothing",
+        "next": [
             "FishNewStoreChooseMaxSuccess",
             "[JumpBack]FishNewStoreChooseMax"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
+        ]
+    },
+    "FishNewStoreScrollUp": {
+        "desc": "万能鱼饵点击失败，向上滚动后重新识别",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "FishNewOnStore"
+                ]
+            }
+        },
+        "action": "Scroll",
+        "target": [
+            220,
+            350
+        ],
+        "dy": 1200,
+        "next": [
+            "FishNewStoreChooseGeneralBait",
+            "FishNewStoreScrollUpAfterMiss"
+        ],
+        "on_error": [
+            "[Anchor]FishNewErrorRestart"
+        ]
+    },
+    "FishNewStoreScrollUpAfterMiss": {
+        "desc": "鱼饵仍未识别到，继续向上滚动",
+        "recognition": {
+            "type": "And",
+            "param": {
+                "all_of": [
+                    "FishNewOnStore"
+                ]
+            }
+        },
+        "action": "Scroll",
+        "target": [
+            220,
+            350
+        ],
+        "dy": 1200,
+        "next": [
+            "FishNewStoreChooseGeneralBait",
+            "FishNewStoreScrollUp"
         ],
         "on_error": [
             "[Anchor]FishNewErrorRestart"
@@ -575,7 +694,7 @@
             "FishNewSellFishEntrance",
             "FishNewConfirmBuyBait",
             "FishNewExitStore"
-        ],//购买的鱼饵数量较少时不会弹出确认界面
+        ], //购买的鱼饵数量较少时不会弹出确认界面
         "on_error": [
             "[Anchor]FishNewErrorRestart"
         ]


### PR DESCRIPTION
# Pull Request

## 关联 Issue

Closes #429 

## 变更摘要

- 为防止点击鱼饵时由于游戏bug，导致click行为被识别成向下大幅滑动（该bug很难复现，但确实存在），将该行为纳入模型
- 具体地：准备购买前，会再次调用verify节点进行一次相同的模板识别，若ROI中未找到鱼鳞币万能鱼饵，则调用scroll节点递归向上滚动，直到目标鱼饵出现在屏幕中并再次点击，以确保可以正确选择到鱼鳞币万能鱼饵
- bug严重性在于，会彻底打断无人值守的挂机导致无法继续

## 验证

- win controller测试通过
- 720p/1080p res 测试通过
- 测试1阶段中增加过自动下滚的节点以模拟bug问题，测试通过
- 测试2阶段中增加了纯等待节点，人为地进行下拉以模拟bug问题，测试通过（该wait节点正式版中未删除，但时间下调为500ms）

## 截图 / 日志 / 说明

- 关于模板识别的正确性验证在关联issue中使用了matplotlib的heatmap进行了证明，应该不是识别错误问题，买成方斯鱼饵应该就是由这个bug引起

## Sourcery 摘要

增强鱼饵购买功能对误滚动操作的容错能力，确保无人值守钓鱼能够持续使用正确的鱼饵。

Bug 修复：
- 防止游戏将购买点击误判为向下滚动时选择错误的鱼饵。

功能增强：
- 添加验证和恢复处理，确保在无人值守钓鱼期间，通用鱼鳞币鱼饵始终可见并处于选中状态。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使诱饵购买能够抵御意外滚动，从而确保无人值守钓鱼时始终使用正确的诱饵。

错误修复：
- 防止游戏将购买点击误判为滚动手势时，钓鱼诱饵购买选择错误的诱饵。

增强功能：
- 添加验证和恢复处理，确保在无人值守钓鱼期间，通用鱼鳞诱饵始终可见并处于选中状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make bait purchasing resilient to accidental scrolling so unattended fishing can continue with the correct bait.

Bug Fixes:
- Prevent fishing bait purchases from selecting the wrong bait when the game misinterprets a purchase click as a scroll gesture.

Enhancements:
- Add verification and recovery handling to keep the universal fish-scale bait visible and selected during unattended fishing.

</details>

</details>